### PR TITLE
Remove unneeded solr params on null search (*:*)

### DIFF
--- a/app/models/spectrum/search_engines/solr.rb
+++ b/app/models/spectrum/search_engines/solr.rb
@@ -188,11 +188,33 @@ module Spectrum
           extra_controller_params[:sort] = @params[:sort]
           @params[:qt] = 'standard' unless @params[:qt] == 'edismax' || @params[:qt] == 'dismax'
           extra_controller_params['qq'] = '"' + RSolr.solr_escape(@params[:q]) + '"'
+
+          if @params[:q] == '*:*'
+            remove_null_search_extraneous_parameters
+          end
+
+
           @search, @documents = get_search_results(@params, extra_controller_params)
         end
 
         self
       end
+
+      NULL_SEARCH_EXTRANEOUS_PARAMS = %w[
+        boost
+        bq
+        qf
+        pf
+        pf2
+        pf3
+        mm
+      ]
+      def remove_null_search_extraneous_parameters
+        NULL_SEARCH_EXTRANEOUS_PARAMS.each do |f|
+          @config.default_solr_params.delete(f)
+        end
+      end
+
 
       def self.generate_rsolr(source, solr_url = nil)
         if source.is_solr?

--- a/ssctest.rb
+++ b/ssctest.rb
@@ -1,0 +1,49 @@
+#!/user/bin/env ruby
+#
+
+require 'simple_solr_client'
+require 'yaml'
+require 'erb'
+
+def get(query)
+  solr_base = ENV['SOLR_URL_BASE'] || 'http://localhost:8025/solr'
+
+  core = SimpleSolrClient::Client.new(solr_base).core('biblio')
+
+  params = YAML.load(ERB.new(File.read('config/foci/mirlyn.yml')).result)['solr_params']
+
+  qf = params['qf']
+  pf = params['pf']
+  mm = params['mm']
+  tie = params['tie']
+
+  default_args = {
+    'wt'   => 'json',
+    'fl'   => 'score,id,title,author',
+    'rows' => 10,
+    'qt'   => 'edismax',
+  }
+
+  args = default_args.merge({'q' => query, 'pf' => pf, 'qf' => qf, 'mm' => mm, 'tie' => tie})
+
+  result = core.get('select', args)
+end
+
+def basics(result_hash, i)
+  [
+    "%2d. %8.2f %s" % [i+1, result_hash['score'], result_hash['title'].first],
+    result_hash['author'].nil? ? nil : (' ' * 13) + result_hash['author'].take(2).join(' | '),
+    (' ' * 13) + 'id: ' + result_hash['id']
+  ].compact
+end
+
+def show(result)
+  result['response']['docs'].each_with_index do |h,i|
+    puts basics(h, i)
+    puts
+  end
+end
+
+def gs(query)
+  show(get(query));
+end


### PR DESCRIPTION

The {!field} query crashes hard when presented with a *:* as the query
value. This has become a problem with its use in the `boost`
function query with the new mirlyn relevancy work.

This commit removes a bunch of extraneous solr params (boost, bq,
qf, pf, etc.) iff q=*:*.