### PR TITLE
Add comment noting special handling of title_stars_with

### DIFF
--- a/config/foci/00-catalog.yml
+++ b/config/foci/00-catalog.yml
@@ -113,6 +113,17 @@ search_fields:
     pf: publishDate
     qf: publishDate
 
+  # NOTE that title_starts_with is hard-coded to always be sent as a phrase (by manually
+  # adding double-quotes around it) in catalog_controller. This is ancient spectrum code
+  # not written by us. The title_l field by itself will *not* work as expected when in the 
+  # qf, so q=one two qf=title_l in the solr admin console will find everything where "one"
+  # is the first word and "two" is the second. 
+  #
+  # This should be fixed with a change to the query parser with some sort of a 
+  # "force phrase" configuration, but how to do that well in the presence of 
+  # field-typed booleans, e.g., title_l:(huck finn OR tom sawyer), will need some
+  # work.
+
   title_starts_with:
     pf: serialTitle_common_l^10 title_l^5
     qf: title_l


### PR DESCRIPTION
Adds a comment to `00-catalog.yaml` noting how the field name `title_starts_with` is hacked to be forced to be a phrase in `catalog_controller.rb`. I got worried when my tests of the raw solr field via the solr console gave crappy results
for unquoted searched (e.g., `q=one two qf=title_l`). 

This code predates us (blame says it was written 8 years ago) and I don't know if we're using
that field name on purpose or we just got lucky, but it seems worth a warning. 