### PR TITLE
SEARCH-1499 Put authors back into Articles citation data.

### DIFF
--- a/config/fields.yml
+++ b/config/fields.yml
@@ -4067,6 +4067,13 @@
 
 - id: primo_author
   uid: author
+  csl:
+    id: author
+    type: author
+  z3988:
+    id: rft.au
+  ris:
+    - AU
   field: creator
   metadata:
     name: Author


### PR DESCRIPTION
This change tags primo authors for various citation and export methods.