### PR TITLE
Make the need to build the Search UI explicit

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -68,7 +68,7 @@ Rake::Task['assets:precompile'].enhance do
     end
     system('mv tmp/search.alt/build/index.html tmp/search.alt/build/app.html') || abort("Couldn't rename index to app")
   end
-end if (`which npm` && $?.success?)
+end if ENV.fetch('SPECTRUM_BUILDS_SEARCH', false)
 
 
 # Doing this lets us test by just typing "rake", but that also means


### PR DESCRIPTION
We used the presence of npm to determine whether Spectrum should
build Search in production, but we kept that separate in Kubernetes.

Making this an explicit environment variable so that builds with
node/npm can choose whether to build Search with asset precompilation.