### PR TITLE
Debugging assistance for docker-compose.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ RUN gem install bundler:1.17.3
 
 USER $UNAME
 
-COPY Gemfile* ${APP_HOME}/
-COPY local-gems/ ${APP_HOME}/local-gems/
+COPY --chown=${UNAME}:${UNAME} Gemfile* ${APP_HOME}/
+COPY --chown=${UNAME}:${UNAME} local-gems/ ${APP_HOME}/local-gems/
 
 RUN bundle install
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Get the actual values for the `.env` file from one of the developers. Update `.e
 
 Build it.
 ```
-docker-compose build
+docker-compose up --build --no-start
 ```
 
 Install the gems into the gem-cache
@@ -51,10 +51,16 @@ docker-compose run --rm web bundle exec rspec
 ```
 
 ### Debugging
-To use a debugger like `byebug`, first start the app with `docker-compose up`. Then in another terminal: 
+Puma doesn't always play nicely with pry.  Worker timeouts can end sessions early, and multi-threading can make taking input from the terminal troublesome.
+
+To address these issues, the `script/docker-startup` file will run in WEBrick when started with the environment variable `RAILS_SERVER` set to webrick.
+
+Changing environment variables in `docker-compose` gets updated when running `docker-compose up` so, to pick up environment variable changes every time, and attach for use with a debugger:
 
 ```
-docker attach "$(docker-compose ps -q web)"
+docker-compose up --no-start web && \
+  docker-compose start web && \
+  docker attach "$(docker-compose ps -q web)"
 ```
 
 ## Overview of Spectrum

--- a/README.md
+++ b/README.md
@@ -10,43 +10,49 @@ Clone the repository
 git clone git@github.com:mlibrary/spectrum.git spectrum
 cd spectrum
 ```
-Copy .env-example to .env
-```
+
+Copy `.env-example` to `.env`
+```bash
 cp .env-example .env
 ```
+
 Get the actual values for the `.env` file from one of the developers. Update `.env` with those values.
 
-Build it.
-```
+Build it:
+```bash
 docker-compose up --build --no-start
 ```
 
-Install the gems into the gem-cache
-```
+Install the gems into the gem-cache:
+```bash
 docker-compose run --rm web bundle install
 ```
 
-Pull the latest version of the search front end
-```
+Pull the latest version of the search front end:
+```bash
 docker-compose run --rm web bundle exec rake 'search[latest,local]'
 ```
 
-Load up the catalog with some example data. To do that you need to start up catalog solr and then index the data.
-
+On a fresh install it is necessary to first manually pull the `catalog-solr` image, which will be used to hold the local example data:
+```bash
+docker-compose pull catalog-solr
 ```
+
+Load up the catalog with some example data. To do that you need to start up `catalog-solr` and then index the data.
+```bash
 docker-compose start catalog-solr
 docker-compose exec catalog-solr bash /examples/load_into_solr.sh
 ```
 
 Then start it
-
-```
+```bash
 docker-compose up
 ```
-In the browser go to `http://localhost:3000`
+In the browser go to [http://localhost:3000](http://localhost:3000)
+
 
 ### Running Tests
-```
+```bash
 docker-compose run --rm web bundle exec rspec
 ```
 
@@ -54,10 +60,18 @@ docker-compose run --rm web bundle exec rspec
 Puma doesn't always play nicely with pry.  Worker timeouts can end sessions early, and multi-threading can make taking input from the terminal troublesome.
 
 To address these issues, the `script/docker-startup` file will run in WEBrick when started with the environment variable `RAILS_SERVER` set to webrick.
+To set `RAILS_SERVER` add it to your `.env` file: 
+```
+RAILS_SERVER=webrick
+```
+
+Additionally, WEBrick needs to run in development mode. Add `RAILS_ENV` to your `.env` to ensure it does:
+```
+RAILS_ENV=development
+```
 
 Changing environment variables in `docker-compose` gets updated when running `docker-compose up` so, to pick up environment variable changes every time, and attach for use with a debugger:
-
-```
+```bash
 docker-compose up --no-start web && \
   docker-compose start web && \
   docker attach "$(docker-compose ps -q web)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       args:
         - UID=${UID}
         - GID=${GID}
-    command: bash -c 'rm -f tmp/pids/server.pid && bundle exec rails s -p ${BIND_PORT} -b ${BIND_IP}'
+    command: script/docker-startup
     env_file:
       - .env-dev-values
       - .env

--- a/script/docker-startup
+++ b/script/docker-startup
@@ -2,8 +2,7 @@
 
 rm -f tmp/pids/server.pid
 
-if [ "x${RAILS_SERVER}" = x"webrick" ] ; then
-  bundle exec rackup -s webrick -p "${BIND_PORT}" -o "${BIND_IP}"
-else
-  bundle exec rails s -p "${BIND_PORT}" -b "${BIND_IP}"
-fi
+bundle exec rackup \
+  -s "${RAILS_SERVER:-puma}" \
+  -p "${BIND_PORT}" \
+  -o "${BIND_IP}"

--- a/script/docker-startup
+++ b/script/docker-startup
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+rm -f tmp/pids/server.pid
+
+if [ "x${RAILS_SERVER}" = x"webrick" ] ; then
+  bundle exec rackup -s webrick -p "${BIND_PORT}" -o "${BIND_IP}"
+else
+  bundle exec rails s -p "${BIND_PORT}" -b "${BIND_IP}"
+fi

--- a/script/run-tests
+++ b/script/run-tests
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker-compose run --rm web bundle exec rspec
+


### PR DESCRIPTION
I've created some scripts that simplify launching Spectrum when debugging, and updated the README.md to show how to use those scripts.

Questions specific to this:
* Does adding to `script/` to assist in launching in the application server in Docker deviate from expectations too much?
* Does providing a mechanism to launch WEBrick instead of Puma complicate things too much?
* Does this make other modes of development and debugging harder?