### PR TITLE
Fix for searching by pmid in Articles.

### DIFF
--- a/config/foci/05-primo-articles.yml
+++ b/config/foci/05-primo-articles.yml
@@ -41,6 +41,9 @@ search_fields:
   keyword:
     pf: .
     qf: .
+  pmid:
+    pf: .
+    qf: .
   any:
     pf: .
     qf: .


### PR DESCRIPTION
This change lets the query parser know that pmid is a valid field to search in primo.