### PR TITLE
Search 1681 article search contains

### DIFF
--- a/config/fields.yml
+++ b/config/fields.yml
@@ -28,6 +28,12 @@
     name: Keyword
   viewable: false
 
+- id: contains
+  query_field: any
+  metadata:
+    name: contains
+  viewable: false
+
 - id: primo_keyword
   uid: keyword
   query_field: any

--- a/config/fields.yml
+++ b/config/fields.yml
@@ -30,13 +30,17 @@
 
 - id: contains
   query_field: any
+  query_precision: contains
   metadata:
     name: contains
   viewable: false
+  feedback: "This search included a contains search"
 
 - id: primo_keyword
   uid: keyword
   query_field: any
+  query_precision: exact
+  feedback: "This search included an exact match search"
   metadata:
     name: Keyword
   viewable: false

--- a/config/foci/05-primo-articles.yml
+++ b/config/foci/05-primo-articles.yml
@@ -41,6 +41,9 @@ search_fields:
   keyword:
     pf: .
     qf: .
+  contains:
+    pf: .
+    qf: .
   pmid:
     pf: .
     qf: .
@@ -88,6 +91,7 @@ fields:
 # Searching
 - primo_all_fields
 - primo_keyword
+- contains
 
 facets:
 - primo_is_scholarly

--- a/local-gems/spectrum-config/lib/spectrum/config/field.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/field.rb
@@ -58,7 +58,8 @@ module Spectrum
       attr_reader :list, :full, :viewable, :searchable, :uid,
                   :field, :sorts, :fields, :query_params, :values,
                   :query_field, :facet_field, :metadata_component, :header_region,
-                  :mapping, :facet_query_field, :reverse_facets
+                  :mapping, :facet_query_field, :reverse_facets, :query_precision,
+                  :query_feedback
 
       type 'default'
 
@@ -83,6 +84,8 @@ module Spectrum
         @values = i.values
         @origin = 'instance'
         @query_field = i.query_field
+        @query_precision = i.query_precision
+        @query_feedback = i.query_feedback
         @facet_field = i.facet_field
         @facet_query_field = i.facet_query_field
         @ris = i.ris
@@ -110,6 +113,8 @@ module Spectrum
         @metadata   = Metadata.new(args['metadata'])
         @field      = args['field'] || args['id']
         @query_field = args['query_field'] || @field
+        @query_precision = args['query_precision'] || @field
+        @query_feedback = args['query_feedback'] || @field
         @facet_field = args['facet_field'] || @field
         @facet_query_field = args['facet_query_field'] || @facet_field
         @uid = args['uid'] || args['id']

--- a/local-gems/spectrum-config/lib/spectrum/config/primo_source.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/primo_source.rb
@@ -35,9 +35,14 @@ module Spectrum
         )
       end
 
+      def precision(field)
+        return 'contains' if field == 'contains'
+        'exact'
+      end
+
       def extract_query(field_mapping, field, conjunction, tree )
         if tree.is_type?('tokens')
-          return "#{field_mapping.fetch(field, field)},exact,#{tree.text}"
+          return "#{field_mapping.fetch(field, field)},#{precision(field)},#{tree.text}"
         elsif ['and', 'or'].any? { |type| tree.is_type?(type) }
           op = tree.operator.to_s.upcase
           return tree.children.map do |child|


### PR DESCRIPTION
This change:
1. Creates a `contains` field to hold the metadata
2. Adds `contains` as a search field for the query parser.
3. Extends the field configuration to add metadata for `query_precision` and `query feedback`
4. Updates the PrimoSource class to use the `query_precision` to specify the precision in primo
5. `query_feedback` is not utilized yet, and the specific messages to send have not been identified. 