### PR TITLE
Filters for RIS exports

### DIFF
--- a/config/fields.yml
+++ b/config/fields.yml
@@ -1954,6 +1954,9 @@
   metadata:
     name: Place of Publication
     short_desc: Place of publication
+  filters:
+    - id: ris_text
+      method: ris_text
 
 - id: marc_300_a
   ris:
@@ -1968,6 +1971,9 @@
     fields:
       - tag: "300"
         sub: "a"
+  filters:
+    - id: marc_300_a
+      method: marc_300_a
 
 - id: marc_264_b
   ris:
@@ -2055,6 +2061,8 @@
       method: sanitize
     - id: trim
       method: trim
+    - id: ris_text
+      method: ris_text
 
 - id: marc_csl_title
   csl:

--- a/local-gems/spectrum-config/lib/spectrum/config/filter.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/filter.rb
@@ -217,6 +217,25 @@ module Spectrum
          value.merge(value: candidate_value)
        end
       end
+
+      def marc_300_a(value, request)
+        case value
+        when Array
+          value.map { |val| marc_300_a(val, request) }
+        when String
+          return nil if value.match(/[^A-Za-z0-9]/)
+          value
+        end
+      end
+
+      def ris_text(value, request)
+        case value
+        when Array
+          value.map { |val| ris_text(val, request) }
+        when String
+          value.gsub(/ : /, ': ').gsub(/ ?[\/:]$/, '')
+        end
+      end
     end
   end
 end

--- a/spec/spectrum-config/spectrum/config/filter_spec.rb
+++ b/spec/spectrum-config/spectrum/config/filter_spec.rb
@@ -66,6 +66,41 @@ describe Spectrum::Config::Filter do
     end
   end
 
+  context "configured with ris_text" do
+    let(:cfg) {{'id' => 'ris_text', 'method' => 'ris_text'}}
+    subject { described_class.new(cfg) }
+    context "#apply" do
+      it "returns nil when given nil" do
+        expect(subject.apply(nil, nil)).to be(nil)
+      end
+      it "returns [] when given []" do
+        expect(subject.apply([], nil)).to eq([])
+      end
+      it "returns 'abc: xyz' when given 'abc : xyz /'" do
+        expect(subject.apply('abc : xyz /', nil)).to eq('abc: xyz')
+      end
+    end
+  end
+
+  context "Configured with marc_300_a" do
+    let(:cfg) {{'id' => 'marc_300_a', 'method' => 'marc_300_a'}}
+    subject { described_class.new(cfg) }
+    context "#apply" do
+      it "returns nil when given nil" do
+        expect(subject.apply(nil, nil)).to be(nil)
+      end
+      it "returns [] when given []" do
+        expect(subject.apply([], nil)).to eq([])
+      end
+      it "returns 'abc' when given 'abc'" do
+        expect(subject.apply('abc', nil)).to eq('abc')
+      end
+      it "returns nil when given '$'" do
+        expect(subject.apply('$', nil)).to be(nil)
+      end
+    end
+  end
+
   context "Configured with boolean" do
     let(:cfg) {{'id' => 'boolean', 'method' => 'boolean'}}
     subject { described_class.new(cfg) }


### PR DESCRIPTION
* 300a must include alphumeric characters only
* titles and publishers should not have spaces before colons, or trailing colons or trailing slashes.