### PR TITLE
LIBSEARCH-819 IS-SEEES AcqWorkOrder is getable

### DIFF
--- a/config/get_this.yml
+++ b/config/get_this.yml
@@ -52,7 +52,7 @@
     - on_shelf?
     - can_request?
 
-# Pickup (1 of 5)
+# Pickup (1 of 6)
 - label: Pick it up at the library
   service_type: Library-to-library
   duration: Expected availability 1-3 days
@@ -87,7 +87,7 @@
       - not_reservable_library?
       - not_game?
 
-# Pickup (2 of 5)
+# Pickup (2 of 6)
 - label: Pick it up at the library
   service_type: Library-to-library
   duration: Expected availability 1-10 days
@@ -121,9 +121,10 @@
       - not_building_use_only?
       - not_reservable_library?
       - not_game?
+      - not_getable_work_order?
 
 
-# Pickup (3 of 5)
+# Pickup (3 of 6)
 - label: Pick it up at the library
   service_type: Library-to-library
   duration: Expected availability 1-2 days
@@ -157,7 +158,7 @@
       - not_building_use_only?
       - not_reservable_library?
 
-# Pickup (4 of 5) WORK_ORDER_DEPARTMENT
+# Pickup (4 of 6) WORK_ORDER_DEPARTMENT Labeling
 - label: Pick it up at the library
   service_type: Library-to-library
   duration: Click to see additional details
@@ -183,13 +184,42 @@
   grants:
     holding:
       - ann_arbor?
-      - in_gettable_workorder?
+      - in_labeling?
       - can_request?
       - not_building_use_only?
       - not_reservable_library?
       - not_game?
+
+# Pickup (5 of 6) WORK_ORDER_DEPARTMENT AcqTechServices for ISEEES
+- label: Pick it up at the library
+  service_type: Library-to-library
+  duration: Expected availability 1-5 days
+  description:
+    heading: Policies and additional details
+    content:
+      - Standard loan and renewal policies apply. #Once checked-out, your item can be recalled by another user.
+      - Can't find your book on the shelf? Request it for pickup, and we will search for it.
+      - The Hatcher pickup desk in the North Lobby is less accessible than our other locations. We suggest you choose nearby Shapiro if you have mobility issues.
+  form:
+    type: alma_hold
+    pickup_locations:
+      -  SHAP
+      -  AAEL
+      -  DHCL
+      -  FINE
+      -  HATCH
+      -  MUSM
+      -  MUSIC
+      -  TAUB
+      -  FLINT
+      -  DBRN
+  grants:
+    holding:
+      - ann_arbor?
+      - in_international_studies_acquisitions_technical_services?
+      - can_request?
         
-# Pickup (5 of 5)
+# Pickup (6 of 6)
 - label: Pick it up at the library
   service_type: Library-to-library
   duration: Click to see additional details

--- a/local-gems/spectrum-json/lib/spectrum/decorators/physical_item_decorator.rb
+++ b/local-gems/spectrum-json/lib/spectrum/decorators/physical_item_decorator.rb
@@ -49,7 +49,7 @@ module Spectrum::Decorators
     ETAS_START = 'Full text available,'
 
     extend Forwardable
-    def_delegators :@work_order_option, :in_gettable_workorder?, :not_in_gettable_workorder?
+    def_delegators :@work_order_option, :in_labeling?, :in_international_studies_acquisitions_technical_services? 
 
     attr_reader :hathi_holding
     def initialize(item, hathi_holdings = [], work_order_option = Spectrum::Entities::GetThisWorkOrderOption.for(item))
@@ -138,6 +138,12 @@ module Spectrum::Decorators
     end
     def not_in_acq?
       !in_acq?
+    end
+    def not_in_labeling?
+      !in_labeling?
+    end
+    def not_in_international_studies_acquisitions_technical_services?
+      !in_international_studies_acquisitions_technical_services?
     end
     def building_use_only?
       @item.fulfillment_unit == "Limited" || @item.item_policy == '08' #08 for Special Collections is also Reading Room Only

--- a/local-gems/spectrum-json/lib/spectrum/entities/get_this_work_order_option.rb
+++ b/local-gems/spectrum-json/lib/spectrum/entities/get_this_work_order_option.rb
@@ -17,8 +17,18 @@ class Spectrum::Entities::GetThisWorkOrderOption
     !in_gettable_workorder?
   end
   def in_gettable_workorder?
+    in_labeling? || in_international_studies_acquitions_techenical_services?
+  end
+
+  def in_labeling?
     ["Labeling"].include?(@data.dig("item_data","work_order_type","value"))
   end
+
+  def in_international_studies_acquitions_techenical_services?
+    ["AcqWorkOrder"].include?(@data.dig("item_data","work_order_type","value")) && 
+    ["IS-SEEES"].include?(@data.dig("item_data","location","value"))
+  end
+  
 
   class GetThisWorkOrderNotApplicable < self
     def initialize

--- a/local-gems/spectrum-json/lib/spectrum/entities/get_this_work_order_option.rb
+++ b/local-gems/spectrum-json/lib/spectrum/entities/get_this_work_order_option.rb
@@ -13,18 +13,12 @@ class Spectrum::Entities::GetThisWorkOrderOption
   def initialize(data)
     @data = data
   end
-  def not_in_gettable_workorder?
-    !in_gettable_workorder?
-  end
-  def in_gettable_workorder?
-    in_labeling? || in_international_studies_acquitions_techenical_services?
-  end
 
   def in_labeling?
     ["Labeling"].include?(@data.dig("item_data","work_order_type","value"))
   end
 
-  def in_international_studies_acquitions_techenical_services?
+  def in_international_studies_acquisitions_technical_services?
     ["AcqWorkOrder"].include?(@data.dig("item_data","work_order_type","value")) && 
     ["IS-SEEES"].include?(@data.dig("item_data","location","value"))
   end
@@ -33,7 +27,10 @@ class Spectrum::Entities::GetThisWorkOrderOption
   class GetThisWorkOrderNotApplicable < self
     def initialize
     end
-    def in_gettable_workorder?
+    def in_international_studies_acquisitions_technical_services?
+      false
+    end
+    def in_labeling?
       false
     end
   end

--- a/spec/spectrum/decorators/physical_item_decorator_spec.rb
+++ b/spec/spectrum/decorators/physical_item_decorator_spec.rb
@@ -8,7 +8,7 @@ describe Spectrum::Decorators::PhysicalItemDecorator do
       solr_item:  double('BibRecord::AlmaItem', process_type: nil, item_policy: '01', barcode: 'somebarcode', fulfillment_unit: "General"),
       bib_record: instance_double(Spectrum::BibRecord)
     }
-    @get_this_work_order_double = instance_double(Spectrum::Entities::GetThisWorkOrderOption, in_gettable_workorder?: "in_gettable_workorder", not_in_gettable_workorder?: "not_in_gettable_workorder")
+    @get_this_work_order_double = instance_double(Spectrum::Entities::GetThisWorkOrderOption, in_labeling?: "in_labeling", in_international_studies_acquisitions_technical_services?: "in_international_studies_acquisitions_technical_services")
   end
   subject do
     item = Spectrum::Entities::AlmaItem.new(**@input)
@@ -17,11 +17,18 @@ describe Spectrum::Decorators::PhysicalItemDecorator do
   context "work order methods" do
     #mrio: both of these would be booleans, but having them return strings shows
     #that the correct path through the code is being used.
-    it "responds to #in_gettable_workorder?" do
-      expect(subject.in_gettable_workorder?).to eq("in_gettable_workorder")
+    it "responds to #in_international_studies_acquisitions_technical_services?" do
+      expect(subject.in_international_studies_acquisitions_technical_services?).to eq("in_international_studies_acquisitions_technical_services")
     end
-    it "responds to #in_gettable_workorder?" do
-      expect(subject.not_in_gettable_workorder?).to eq("not_in_gettable_workorder")
+    it "responds to #not_in_international_studies_acquisitions_technical_services?" do
+      expect(subject.not_in_international_studies_acquisitions_technical_services?).to eq(false)
+    end
+    it "responds to #in_labeling?" do
+      expect(subject.in_labeling?).to eq("in_labeling")
+    end
+    
+    it "responds to #not_in_labeling?" do
+      expect(subject.not_in_labeling?).to eq(false)
     end
   end
   context "#game?" do

--- a/spec/spectrum/entities/get_this_work_order_option_spec.rb
+++ b/spec/spectrum/entities/get_this_work_order_option_spec.rb
@@ -1,41 +1,63 @@
 require_relative '../../rails_helper'
 describe Spectrum::Entities::GetThisWorkOrderOption do
   before(:each) do
-     @item = double('Spectrum::Decorators::PhysicalItemDecorator', location: 'HATCH', process_type: false)
+     @item = double('Spectrum::Decorators::PhysicalItemDecorator', location: 'HATCH', process_type: "WORK_ORDER_DEPARTMENT", barcode: "BARCODE")
      @alma_item = JSON.parse(File.read('./spec/fixtures/get_this/alma_work_order_item.json'))
   end
   subject do
     stub_alma_get_request(url: "items", output: @alma_item.to_json, query: {item_barcode: 'BARCODE'})
     described_class.for(@item)
   end
-  context "#in_gettable_workorder?" do
-    it "false when no process type and not gettable location" do
-      expect(subject.in_gettable_workorder?).to eq(false)
+  context ".for" do
+    it "returns a GetThisWorkOrderOption object for an item with a WORK_ORDER_DEPARTMENT process type" do 
+      expect(subject.class.to_s).to include("GetThisWorkOrderOption")
     end
-    it "is true when both in a work order department and it's in the correct work order department" do
-      allow(@item).to receive(:process_type).and_return('WORK_ORDER_DEPARTMENT')
-      allow(@item).to receive(:barcode).and_return('BARCODE')
-      expect(subject.in_gettable_workorder?).to eq(true)
+    it "returns a GetThisWorkOrderNotApplicable object for an item with a non work order process type" do 
+      allow(@item).to receive(:process_type).and_return("IN_TRANSIT")
+      expect(subject.class.to_s).to include("GetThisWorkOrderNotApplicable")
     end
-    it "is true when in IS-SEEES and in Acquitions Technical Services" do
-      @alma_item["item_data"]["work_order_type"]["value"] = "AcqWorkOrder"
-      @alma_item["item_data"]["location"]["value"] = "IS-SEEES"
-      allow(@item).to receive(:process_type).and_return('WORK_ORDER_DEPARTMENT')
-      allow(@item).to receive(:barcode).and_return('BARCODE')
-      expect(subject.in_gettable_workorder?).to eq(true)
-    end
-    it "is false when in the incorrect work order department" do
-      @alma_item["item_data"]["work_order_type"]["value"] = "NOT_A_REQUESTABLE_WORK_ORDER_DEPT"
-      allow(@item).to receive(:process_type).and_return("WORK_ORDER_DEPARTMENT")
-      allow(@item).to receive(:barcode).and_return("BARCODE")
-      expect(subject.in_gettable_workorder?).to eq(false)
-    end
-    it "is false when in Acquitions Technical Services, but not IS-SEEES" do
-      @alma_item["item_data"]["work_order_type"]["value"] = "AcqWorkOrder"
-      allow(@item).to receive(:process_type).and_return('WORK_ORDER_DEPARTMENT')
-      allow(@item).to receive(:barcode).and_return('BARCODE')
-      expect(subject.in_gettable_workorder?).to eq(false)
+    it "returns a GetThisWorkOrderNotApplicable if the api response returns not 200" do 
+      stub_alma_get_request(url: "items", query: {item_barcode: 'BARCODE'}, status: 500)
+      expect(described_class.for(@item).class.to_s).to include("GetThisWorkOrderNotApplicable")
     end
   end
-
+  context "#in_labeling?" do
+    it "is true when an item is in labeling" do
+      expect(subject.in_labeling?).to eq(true)
+    end
+    it "is false when no item that isn't in labeling" do
+      @alma_item["item_data"]["work_order_type"]["value"] = "NOT_A_REQUESTABLE_WORK_ORDER_DEPT"
+      expect(subject.in_labeling?).to eq(false)
+    end
+  end
+  context "in_international_studies_acquisitions_technical_services?" do
+    it "is true when an item is in international studies and is in the AqcWork Order" do
+      @alma_item["item_data"]["work_order_type"]["value"] = "AcqWorkOrder"
+      @alma_item["item_data"]["location"]["value"] = "IS-SEEES"
+      expect(subject.in_international_studies_acquisitions_technical_services?).to eq(true)
+    end
+    it "is false for an AcqWorkOrder item not in IS-SEES" do
+      @alma_item["item_data"]["work_order_type"]["value"] = "AcqWorkOrder"
+      expect(subject.in_international_studies_acquisitions_technical_services?).to eq(false)
+    end
+    it "is false for an item is IS-SEES that isn't in the AcqWorkOrder" do
+      @alma_item["item_data"]["location"]["value"] = "IS-SEEES"
+      expect(subject.in_international_studies_acquisitions_technical_services?).to eq(false)
+    end
+  end
+end
+describe Spectrum::Entities::GetThisWorkOrderOption::GetThisWorkOrderNotApplicable do
+  subject do
+    described_class.new
+  end
+  context "#in_international_studies_acquisitions_technical_services?" do
+    it "is false" do
+      expect(subject.in_international_studies_acquisitions_technical_services?).to eq(false)
+    end
+  end
+  context "#in_labeling?" do
+    it "is false" do
+      expect(subject.in_labeling?).to eq(false)
+    end
+  end
 end

--- a/spec/spectrum/entities/get_this_work_order_option_spec.rb
+++ b/spec/spectrum/entities/get_this_work_order_option_spec.rb
@@ -5,6 +5,7 @@ describe Spectrum::Entities::GetThisWorkOrderOption do
      @alma_item = JSON.parse(File.read('./spec/fixtures/get_this/alma_work_order_item.json'))
   end
   subject do
+    stub_alma_get_request(url: "items", output: @alma_item.to_json, query: {item_barcode: 'BARCODE'})
     described_class.for(@item)
   end
   context "#in_gettable_workorder?" do
@@ -12,16 +13,27 @@ describe Spectrum::Entities::GetThisWorkOrderOption do
       expect(subject.in_gettable_workorder?).to eq(false)
     end
     it "is true when both in a work order department and it's in the correct work order department" do
-      stub_alma_get_request(url: "items", output: @alma_item.to_json, query: {item_barcode: 'BARCODE'})
+      allow(@item).to receive(:process_type).and_return('WORK_ORDER_DEPARTMENT')
+      allow(@item).to receive(:barcode).and_return('BARCODE')
+      expect(subject.in_gettable_workorder?).to eq(true)
+    end
+    it "is true when in IS-SEEES and in Acquitions Technical Services" do
+      @alma_item["item_data"]["work_order_type"]["value"] = "AcqWorkOrder"
+      @alma_item["item_data"]["location"]["value"] = "IS-SEEES"
       allow(@item).to receive(:process_type).and_return('WORK_ORDER_DEPARTMENT')
       allow(@item).to receive(:barcode).and_return('BARCODE')
       expect(subject.in_gettable_workorder?).to eq(true)
     end
     it "is false when in the incorrect work order department" do
       @alma_item["item_data"]["work_order_type"]["value"] = "NOT_A_REQUESTABLE_WORK_ORDER_DEPT"
-      stub_alma_get_request(url: "items", output: @alma_item.to_json, query: {item_barcode: 'BARCODE'})
       allow(@item).to receive(:process_type).and_return("WORK_ORDER_DEPARTMENT")
       allow(@item).to receive(:barcode).and_return("BARCODE")
+      expect(subject.in_gettable_workorder?).to eq(false)
+    end
+    it "is false when in Acquitions Technical Services, but not IS-SEEES" do
+      @alma_item["item_data"]["work_order_type"]["value"] = "AcqWorkOrder"
+      allow(@item).to receive(:process_type).and_return('WORK_ORDER_DEPARTMENT')
+      allow(@item).to receive(:barcode).and_return('BARCODE')
       expect(subject.in_gettable_workorder?).to eq(false)
     end
   end


### PR DESCRIPTION
This PR addresses [LIBSEARCH-819](https://mlit.atlassian.net/browse/LIBSEARCH-819)

It marks items in IS-SEEES location in the AcqWorkOrder as `in_international_studies_acquisitions_technical_services`. It has the same wording as items in the labeling as a regular "Pick it up at the library", but the number of days is 5 instead of 3.

The get-this option will look like this:
![image-20230117-163116](https://user-images.githubusercontent.com/4235919/212958711-3be9a7ed-077f-49e2-83b1-d75a59db1d18.png)

