### PR TITLE
Bugfix: Flint get this items weren't showing

### DIFF
--- a/config/get_this.yml
+++ b/config/get_this.yml
@@ -123,8 +123,6 @@
       - not_building_use_only?
       - not_reservable_library?
       - not_game?
-      - not_getable_work_order?
-
 
 # Pickup (3 of 6)
 - label: Pick it up at the library


### PR DESCRIPTION
There was a reference to a method that doesn't exist. I removed that check and it works now.

Example item: http://localhost:3000/catalog/record/990044965460106381/get-this/49015001137323