### PR TITLE
Profile photos were being downloaded with permission 600.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,6 +49,7 @@ namespace 'assets' do
         dest_file = 'public' + '/photos' + url_parsed.path
         FileUtils.mkdir_p(File.dirname(dest_file))
         Down.download(url_string, destination: dest_file)
+        FileUtils.chmod('ug=rw,o=r', dest_file)
       end
       puts "Finished downloading profile photos"
     end

--- a/Rakefile
+++ b/Rakefile
@@ -46,7 +46,7 @@ namespace 'assets' do
         next unless url_string
         next if url_string.empty?
         url_parsed = URI(url_string)
-        dest_file = 'public' + '/photos' + url_parsed.path
+        dest_file = CGI.unescape('public' + '/photos' + url_parsed.path)
         FileUtils.mkdir_p(File.dirname(dest_file))
         Down.download(url_string, destination: dest_file)
         FileUtils.chmod('ug=rw,o=r', dest_file)


### PR DESCRIPTION
The webserver was then unable to serve the files when permission was set to 600.
664 is more acceptable in the current deployment arrangement.