### PR TITLE
Libsearch 879 Closed stacks uses fulfillment unit and location type

### DIFF
--- a/local-gems/spectrum-json/lib/spectrum/available_online_holding.rb
+++ b/local-gems/spectrum-json/lib/spectrum/available_online_holding.rb
@@ -14,20 +14,19 @@ module Spectrum
     # Things that respond with Available Online
     [:location, :status].each do |name|
       define_method(name) do
-        'Available Online'
+        "Available Online"
       end
     end
-
 
     # Things that respond with the empty string
     [:callnumber, :notes, :issue, :full_item_key].each do |name|
       define_method(name) do
-        ''
+        ""
       end
     end
 
     # Things that respond with true
-    [:off_site?, :circulating?, :can_request?, :mobile?, :off_shelf?].each do |name|
+    [:closed_stacks?, :circulating?, :can_request?, :mobile?, :off_shelf?].each do |name|
       define_method(name) do
         true
       end
@@ -35,11 +34,11 @@ module Spectrum
 
     # Things that respond with false
     [:can_book?, :can_reserve?, :circulating?, :on_shelf?,
-     :building_use_only?, :missing?, :known_off_shelf?,
-     :on_site?, :checked_out?, :reopened?].each do |name|
-       define_method(name) do
-         false
-       end
+      :building_use_only?, :missing?, :known_off_shelf?,
+      :open_stacks?, :checked_out?, :reopened?].each do |name|
+      define_method(name) do
+        false
+      end
     end
   end
 end

--- a/local-gems/spectrum-json/lib/spectrum/bib_record.rb
+++ b/local-gems/spectrum-json/lib/spectrum/bib_record.rb
@@ -321,7 +321,7 @@ module Spectrum
         ["description", "public_note", "barcode", "library", "location",
           "permanent_library", "permanent_location", "process_type",
           "callnumber", "item_policy", "inventory_number", "item_id",
-          "fulfillment_unit", "record_has_finding_aid"].each do |name|
+          "fulfillment_unit", "location_type", "record_has_finding_aid"].each do |name|
           define_method(name) do
             @item[name]
           end

--- a/local-gems/spectrum-json/lib/spectrum/decorators/physical_item_decorator.rb
+++ b/local-gems/spectrum-json/lib/spectrum/decorators/physical_item_decorator.rb
@@ -195,16 +195,6 @@ module Spectrum::Decorators
       !not_on_shelf?
     end
 
-    # Deprecated.  I think the semantics people care about now is open/closed stacks.
-    def off_site?
-      @item.library_display_name.start_with?("Offsite", "- Offsite") || @item.fulfillment_unit == "Closed Stacks"
-    end
-
-    # Deprecated.  I think the semantics people care about now is open/closed stacks.
-    def on_site?
-      !off_site?
-    end
-
     def closed_stacks?
       @item.fulfillment_unit == "Closed Stacks"
     end

--- a/local-gems/spectrum-json/lib/spectrum/decorators/physical_item_decorator.rb
+++ b/local-gems/spectrum-json/lib/spectrum/decorators/physical_item_decorator.rb
@@ -197,7 +197,7 @@ module Spectrum::Decorators
 
     # Deprecated.  I think the semantics people care about now is open/closed stacks.
     def off_site?
-      @item.library_display_name.start_with?("Offsite", "- Offsite")
+      @item.library_display_name.start_with?("Offsite", "- Offsite") || @item.fulfillment_unit == "Closed Stacks"
     end
 
     # Deprecated.  I think the semantics people care about now is open/closed stacks.
@@ -206,7 +206,7 @@ module Spectrum::Decorators
     end
 
     def closed_stacks?
-      @item.library_display_name.start_with?("Offsite", "- Offsite", "Buhr")
+      @item.fulfillment_unit == "Closed Stacks"
     end
 
     def open_stacks?

--- a/local-gems/spectrum-json/lib/spectrum/decorators/physical_item_decorator.rb
+++ b/local-gems/spectrum-json/lib/spectrum/decorators/physical_item_decorator.rb
@@ -196,7 +196,7 @@ module Spectrum::Decorators
     end
 
     def closed_stacks?
-      @item.fulfillment_unit == "Closed Stacks"
+      ["CLOSED", "NOT_LIB", "REMOTE", "UNAVAIL"].include?(@item.location_type) || @item.fulfillment_unit == "Closed Stacks"
     end
 
     def open_stacks?

--- a/local-gems/spectrum-json/lib/spectrum/empty_item_holding.rb
+++ b/local-gems/spectrum-json/lib/spectrum/empty_item_holding.rb
@@ -36,7 +36,7 @@ module Spectrum
     end
 
     # Things that respond with true
-    [:off_site?, :can_request?, :mobile?, :off_shelf?,
+    [:closed_stacks?, :can_request?, :mobile?, :off_shelf?,
       :ann_arbor?, :not_on_shelf?, :not_reservable_library?].each do |name|
       define_method(name) do
         true
@@ -45,8 +45,8 @@ module Spectrum
 
     # Things that respond with false
     [:can_book?, :can_reserve?, :circulating?, :on_shelf?, :building_use_only?,
-      :missing?, :known_off_shelf?, :on_site?, :checked_out?, :reopened?,
-      :open_stacks?, :flint?, :in_labeling?, :in_acq?, :reservable_library?,
+      :missing?, :known_off_shelf?, :open_stacks?, :checked_out?, :reopened?,
+      :flint?, :in_labeling?, :in_acq?, :reservable_library?,
       :in_international_studies_acquisitions_technical_services?,
       :recallable?].each do |name|
       define_method(name) do

--- a/local-gems/spectrum-json/lib/spectrum/entities/alma_item.rb
+++ b/local-gems/spectrum-json/lib/spectrum/entities/alma_item.rb
@@ -11,7 +11,7 @@ class Spectrum::Entities::AlmaItem
   def_delegators :@solr_item, :callnumber, :temp_location?, :barcode, :library,
     :location, :permanent_library, :permanent_location, :description, :item_policy,
     :process_type, :inventory_number, :can_reserve?, :item_id, :record_has_finding_aid,
-    :item_location_text, :item_location_link, :fulfillment_unit
+    :item_location_text, :item_location_link, :fulfillment_unit, :location_type
 
   def initialize(holding:, solr_item:, bib_record:, alma_loan: nil)
     @holding = holding # AlmaHolding

--- a/local-gems/spectrum-json/lib/spectrum/entities/alma_item.rb
+++ b/local-gems/spectrum-json/lib/spectrum/entities/alma_item.rb
@@ -39,6 +39,7 @@ class Spectrum::Entities::AlmaItem
     @alma_loan&.dig("due_date")
   end
 
+  # Library and Location name
   def library_display_name
     @holding.display_name
   end

--- a/spec/spectrum/bib_record_spec.rb
+++ b/spec/spectrum/bib_record_spec.rb
@@ -1,35 +1,35 @@
 # frozen_string_literal: true
 
-require_relative '../rails_helper'
+require_relative "../rails_helper"
 
 describe Spectrum::BibRecord do
   before(:each) do
-    @solr_bib_alma = File.read('./spec/fixtures/solr_bib_alma.json')
+    @solr_bib_alma = File.read("./spec/fixtures/solr_bib_alma.json")
   end
   subject do
     described_class.new(JSON.parse(@solr_bib_alma))
   end
 
-  context '#mms_id' do
+  context "#mms_id" do
     it "returns a string" do
-      expect(subject.mms_id).to eq('990020578280106381')
+      expect(subject.mms_id).to eq("990020578280106381")
     end
   end
-  #needs to have bib Holdings.
-  context '#holdings' do
+  # needs to have bib Holdings.
+  context "#holdings" do
     it "returns an array" do
-      expect(subject.holdings.class.name).to eq('Array')
+      expect(subject.holdings.class.name).to eq("Array")
     end
     context "alma holding" do
       let(:alma_holding) { subject.holdings.first }
       it "has a library" do
-        expect(alma_holding.library).to eq('HATCH')
+        expect(alma_holding.library).to eq("HATCH")
       end
       it "has a location" do
-        expect(alma_holding.location).to eq('GRAD')
+        expect(alma_holding.location).to eq("GRAD")
       end
       it "has a callnumber" do
-        expect(alma_holding.callnumber).to eq('LB 2331.72 .S371 1990')
+        expect(alma_holding.callnumber).to eq("LB 2331.72 .S371 1990")
       end
       it "has a public_note" do
         expect(alma_holding.public_note).to eq("")
@@ -66,7 +66,7 @@ describe Spectrum::BibRecord do
 
     context "#alma_holding(holding_id)" do
       it "returns the alma holding for a given holding id" do
-        expect(subject.alma_holding("22957681780006381").callnumber).to eq('LB 2331.72 .S371 1990')  
+        expect(subject.alma_holding("22957681780006381").callnumber).to eq("LB 2331.72 .S371 1990")
       end
       it "returns nil for no matching holding" do
         expect(subject.alma_holding("not_a_holding_id")).to be_nil
@@ -74,7 +74,7 @@ describe Spectrum::BibRecord do
     end
     context "an alma holding" do
       let(:alma_holding) { subject.holdings[0] }
-      ['holding_id', 'location', 'callnumber', 'public_note', 'items', 'summary_holdings'].each do |method|
+      ["holding_id", "location", "callnumber", "public_note", "items", "summary_holdings"].each do |method|
         context "##{method}" do
           it "respond_to? #{method}" do
             expect(alma_holding.respond_to?(method)).to be(true)
@@ -83,11 +83,11 @@ describe Spectrum::BibRecord do
       end
     end
     context "an alma item" do
-      let(:alma_item){ subject.holdings[0].items[0] }
-      ['library','location','description','public_note','barcode',
-      'item_policy','process_type','permanent_location','permanent_library',
-      'id','temp_location?','callnumber', 'inventory_number', "item_id", 
-      "fulfillment_unit", "record_has_finding_aid"].each do |method|
+      let(:alma_item) { subject.holdings[0].items[0] }
+      ["library", "location", "description", "public_note", "barcode",
+        "item_policy", "process_type", "permanent_location", "permanent_library",
+        "id", "temp_location?", "callnumber", "inventory_number", "item_id",
+        "fulfillment_unit", "location_type", "record_has_finding_aid"].each do |method|
         context "##{method}" do
           it "respond_to? #{method}" do
             expect(alma_item.respond_to?(method)).to be(true)
@@ -106,7 +106,7 @@ describe Spectrum::BibRecord do
       end
       context "#item_location_link" do
         it "returns a string" do
-          expect(alma_item.item_location_link).to eq('https://lib.umich.edu/locations-and-hours/hatcher-library')
+          expect(alma_item.item_location_link).to eq("https://lib.umich.edu/locations-and-hours/hatcher-library")
         end
       end
     end
@@ -115,7 +115,7 @@ describe Spectrum::BibRecord do
         expect(subject.physical_holdings?).to eq(true)
       end
       it "returns false for only holdings with library ELEC" do
-        @solr_bib_alma = @solr_bib_alma.gsub(/HATCH/, 'ELEC')
+        @solr_bib_alma = @solr_bib_alma.gsub(/HATCH/, "ELEC")
         expect(subject.physical_holdings?).to eq(false)
       end
     end
@@ -124,7 +124,7 @@ describe Spectrum::BibRecord do
         expect(subject.hathi_holding.class.name.to_s).to eq("Spectrum::BibRecord::HathiHolding")
       end
       it "returns nil for no Hathi Item" do
-        @solr_bib_alma = @solr_bib_alma.gsub(/HathiTrust/, 'SomeOtherTrust')
+        @solr_bib_alma = @solr_bib_alma.gsub(/HathiTrust/, "SomeOtherTrust")
         expect(subject.hathi_holding).to be_nil
       end
     end
@@ -164,7 +164,7 @@ describe Spectrum::BibRecord do
     end
     context "bib record with ELEC holdings" do
       before(:each) do
-        @solr_elec = File.read('./spec/fixtures/solr_elec.json')
+        @solr_elec = File.read("./spec/fixtures/solr_elec.json")
       end
       subject do
         described_class.new(JSON.parse(@solr_elec))
@@ -184,12 +184,12 @@ describe Spectrum::BibRecord do
         end
         it "returns holding when there is a finding_aid" do
           @solr_elec = @solr_elec.gsub(/finding_aid\\":false/, "finding_aid\\\":true")
-          expect(subject.finding_aid.class.name).to include('FindingAid')
+          expect(subject.finding_aid.class.name).to include("FindingAid")
         end
       end
       context "electronic holding" do
-        let(:elec_holding){subject.holdings.first}
-        ['link','library','status','link_text','note','description','finding_aid'].each do |method|
+        let(:elec_holding) { subject.holdings.first }
+        ["link", "library", "status", "link_text", "note", "description", "finding_aid"].each do |method|
           context "##{method}" do
             it "respond_to? #{method}" do
               expect(elec_holding.respond_to?(method)).to be(true)
@@ -197,137 +197,131 @@ describe Spectrum::BibRecord do
           end
         end
         it "actually returns the right thing for an element" do
-           expect(elec_holding.status).to eq('Available') 
-
+          expect(elec_holding.status).to eq("Available")
         end
-        
       end
-
     end
-
   end
-  context '#title' do
-    it 'returns a string' do
-      expect(subject.title).to eq('Enhancing faculty careers : strategies for development and renewal /')
+  context "#title" do
+    it "returns a string" do
+      expect(subject.title).to eq("Enhancing faculty careers : strategies for development and renewal /")
     end
   end
 
-  context '#issn' do
-    it 'returns a string' do
-      expect(subject.issn).to eq('')
+  context "#issn" do
+    it "returns a string" do
+      expect(subject.issn).to eq("")
     end
   end
 
-  context '#isbn' do
-    it 'returns a string' do
-      expect(subject.isbn).to eq('9781555422103')
+  context "#isbn" do
+    it "returns a string" do
+      expect(subject.isbn).to eq("9781555422103")
     end
   end
 
-  context '#bib.accession_number' do
-    it 'returns a string' do
-      expect(subject.accession_number).to eq('<accession_number>20758549</accession_number>')
+  context "#bib.accession_number" do
+    it "returns a string" do
+      expect(subject.accession_number).to eq("<accession_number>20758549</accession_number>")
     end
   end
 
-  context '#author' do
-    it 'returns a string' do
-      expect(subject.author).to eq('Schuster, Jack H.')
+  context "#author" do
+    it "returns a string" do
+      expect(subject.author).to eq("Schuster, Jack H.")
     end
   end
 
-  context '#date' do
-    it 'returns a string' do
-      expect(subject.date).to eq('1990')
+  context "#date" do
+    it "returns a string" do
+      expect(subject.date).to eq("1990")
     end
   end
 
-  context '#pub' do
-    it 'returns a string' do
-      expect(subject.pub).to eq('Jossey-Bass Publishers')
+  context "#pub" do
+    it "returns a string" do
+      expect(subject.pub).to eq("Jossey-Bass Publishers")
     end
   end
 
-  context '#place' do
-    it 'returns a string' do
-      expect(subject.place).to eq('San Francisco ')
+  context "#place" do
+    it "returns a string" do
+      expect(subject.place).to eq("San Francisco ")
     end
   end
 
-  context '#edition' do
-    it 'returns a string' do
-      expect(subject.edition).to eq('1st ed.')
+  context "#edition" do
+    it "returns a string" do
+      expect(subject.edition).to eq("1st ed.")
     end
   end
 
-  context '#callnumber' do
-    it 'returns a string' do
-      expect(subject.callnumber).to eq('LB 2331.72 .S371 1990')
+  context "#callnumber" do
+    it "returns a string" do
+      expect(subject.callnumber).to eq("LB 2331.72 .S371 1990")
     end
   end
-  context '#restriction' do
-    it 'returns a string' do
-      expect(subject.restriction).to eq('')
+  context "#restriction" do
+    it "returns a string" do
+      expect(subject.restriction).to eq("")
     end
   end
-  context '#pub_date' do
-    it 'returns a string' do
-      expect(subject.pub_date).to eq('')
+  context "#pub_date" do
+    it "returns a string" do
+      expect(subject.pub_date).to eq("")
     end
   end
-  context '#publisher' do
-    it 'returns a string' do
-      expect(subject.publisher).to eq('San Francisco : Jossey-Bass Publishers, 1990.')
+  context "#publisher" do
+    it "returns a string" do
+      expect(subject.publisher).to eq("San Francisco : Jossey-Bass Publishers, 1990.")
     end
   end
-  context '#physical_description' do
-    it 'returns a string' do
-      expect(subject.physical_description).to eq('xxiv, 346 p. : ill. ; 24 cm')
+  context "#physical_description" do
+    it "returns a string" do
+      expect(subject.physical_description).to eq("xxiv, 346 p. : ill. ; 24 cm")
     end
   end
-  context '#genre' do
-    it 'returns a string' do
+  context "#genre" do
+    it "returns a string" do
       expect(subject.genre).to be_nil
     end
   end
-  context '#sgenre' do
-    it 'returns a string or nil' do
+  context "#sgenre" do
+    it "returns a string or nil" do
       expect(subject.sgenre).to be_nil
     end
   end
-  context '#fmt' do
-    it 'returns a string' do
+  context "#fmt" do
+    it "returns a string" do
       expect(subject.fmt).to eq("")
     end
   end
-  context '#physical_only?' do
-    it 'returns a boolean' do
+  context "#physical_only?" do
+    it "returns a boolean" do
       expect(subject.physical_only?).to eq(true)
     end
   end
-
 end
 
 describe Spectrum::BibRecord::ElectronicHolding do
-
   context "#link" do
-    subject { described_class.new({'link' => url}) }
+    subject { described_class.new({"link" => url}) }
 
     context "When the holding has an Alma link" do
-      let(:url) { 'https://na04.alma.exlibrisgroup.com' }
+      let(:url) { "https://na04.alma.exlibrisgroup.com" }
 
-       it "Returns the Alma link unchanged" do
-          expect(subject.link).to eq(url)
-       end
+      it "Returns the Alma link unchanged" do
+        expect(subject.link).to eq(url)
+      end
     end
 
     context "When the holding has an non-Alma link" do
-      let(:url) { 'https://www.lib.umich.edu' }
+      let(:url) { "https://www.lib.umich.edu" }
       let(:proxied_url) { "https://apps.lib.umich.edu/proxy-login/?url=#{url}" }
 
-       it "Returns the proxied link" do
-          expect(subject.link).to eq(proxied_url)
-       end
+      it "Returns the proxied link" do
+        expect(subject.link).to eq(proxied_url)
+      end
     end
   end
 end

--- a/spec/spectrum/decorators/physical_item_decorator_spec.rb
+++ b/spec/spectrum/decorators/physical_item_decorator_spec.rb
@@ -372,6 +372,13 @@ describe Spectrum::Decorators::PhysicalItemDecorator do
       expect(subject.not_in_acq?).to eq(false)
     end
   end
+  context "#closed_stacks?" do
+    it "is true if the fulfillment_unit is 'Closed Stacks'" do
+      allow(@input[:solr_item]).to receive(:fulfillment_unit).and_return("Closed Stacks")
+      allow(@input[:holding]).to receive(:display_name).and_return("DISPLAY_NAME")
+      expect(subject.closed_stacks?).to eq(true)
+    end
+  end
   context "#recallable?" do
     it "is true for non reserve item,  that's on loan" do
       allow(@input[:solr_item]).to receive(:process_type).and_return("LOAN")
@@ -380,12 +387,12 @@ describe Spectrum::Decorators::PhysicalItemDecorator do
       @input[:alma_loan] = "not_nil"
       expect(subject.recallable?).to eq(true)
     end
-  end
-  it "is false for reserve item that's in process" do
-    allow(@input[:solr_item]).to receive(:process_type).and_return("LOAN")
-    @input[:alma_loan] = "not_nil"
-    allow(@input[:solr_item]).to receive(:library).and_return("HATCH")
-    allow(@input[:solr_item]).to receive(:location).and_return("RESC")
-    expect(subject.recallable?).to eq(false)
+    it "is false for reserve item that's in process" do
+      allow(@input[:solr_item]).to receive(:process_type).and_return("LOAN")
+      @input[:alma_loan] = "not_nil"
+      allow(@input[:solr_item]).to receive(:library).and_return("HATCH")
+      allow(@input[:solr_item]).to receive(:location).and_return("RESC")
+      expect(subject.recallable?).to eq(false)
+    end
   end
 end

--- a/spec/spectrum/decorators/physical_item_decorator_spec.rb
+++ b/spec/spectrum/decorators/physical_item_decorator_spec.rb
@@ -374,9 +374,28 @@ describe Spectrum::Decorators::PhysicalItemDecorator do
   end
   context "#closed_stacks?" do
     it "is true if the fulfillment_unit is 'Closed Stacks'" do
+      allow(@input[:solr_item]).to receive(:location_type).and_return("OPEN")
       allow(@input[:solr_item]).to receive(:fulfillment_unit).and_return("Closed Stacks")
       allow(@input[:holding]).to receive(:display_name).and_return("DISPLAY_NAME")
       expect(subject.closed_stacks?).to eq(true)
+    end
+    it "is true if the location type is closed but the fulfillment unit is limited" do
+      allow(@input[:solr_item]).to receive(:location_type).and_return("CLOSED")
+      allow(@input[:solr_item]).to receive(:fulfillment_unit).and_return("Limited")
+      allow(@input[:holding]).to receive(:display_name).and_return("DISPLAY_NAME")
+      expect(subject.closed_stacks?).to eq(true)
+    end
+    it "is false if the location type is OPEN and the fulfillment unit is Limited" do
+      allow(@input[:solr_item]).to receive(:location_type).and_return("OPEN")
+      allow(@input[:solr_item]).to receive(:fulfillment_unit).and_return("Limited")
+      allow(@input[:holding]).to receive(:display_name).and_return("DISPLAY_NAME")
+      expect(subject.closed_stacks?).to eq(false)
+    end
+    it "is false if location type is nil and fulfillment unit is Limited" do
+      allow(@input[:solr_item]).to receive(:location_type).and_return(nil)
+      allow(@input[:solr_item]).to receive(:fulfillment_unit).and_return("Limited")
+      allow(@input[:holding]).to receive(:display_name).and_return("DISPLAY_NAME")
+      expect(subject.closed_stacks?).to eq(false)
     end
   end
   context "#recallable?" do

--- a/spec/spectrum/empty_item_holding_spec.rb
+++ b/spec/spectrum/empty_item_holding_spec.rb
@@ -29,7 +29,7 @@ describe Spectrum::EmptyItemHolding do
       end
     end
   end
-  [:off_site?, :can_request?, :mobile?, :off_shelf?, :ann_arbor?,
+  [:closed_stacks?, :can_request?, :mobile?, :off_shelf?, :ann_arbor?,
     :not_on_shelf?, :not_reservable_library?].each do |method|
     context "##{method}" do
       it "returns true" do
@@ -38,7 +38,7 @@ describe Spectrum::EmptyItemHolding do
     end
   end
   [:can_book?, :can_reserve?, :circulating?, :on_shelf?, :building_use_only?,
-    :missing?, :known_off_shelf?, :on_site?, :checked_out?, :reopened?,
+    :missing?, :known_off_shelf?, :checked_out?, :reopened?,
     :open_stacks?, :flint?, :in_labeling?, :in_acq?, :reservable_library?,
     :in_international_studies_acquisitions_technical_services?,
     :recallable?].each do |method|

--- a/spec/spectrum/entities/alma_item_spec.rb
+++ b/spec/spectrum/entities/alma_item_spec.rb
@@ -52,6 +52,9 @@ describe Spectrum::Entities::AlmaItem do
   it "has fulfillment_unit" do
     expect(subject.fulfillment_unit).to eq("General")
   end
+  it "has a location_type" do
+    expect(subject.location_type).to eq(nil)
+  end
   it "has a due_date" do
     expect(subject.due_date).to eq("2021-10-01T03:59:00Z")
   end


### PR DESCRIPTION
This pull request corresponds to [LIBSEARCH-879](https://mlit.atlassian.net/browse/LIBSEARCH-879)

It removes `on_site?` and `off_site?`. 
It has `closed_stacks?` and `open_stacks?` be determined by the Alma fulfillment unit and Alma location type. These are updated with a full reindex so we should not deploy this until after a full reindex. 