### PR TITLE
Alma Digital as a kind of ElectronicItemPresenter

### DIFF
--- a/local-gems/spectrum-json/lib/spectrum/bib_record.rb
+++ b/local-gems/spectrum-json/lib/spectrum/bib_record.rb
@@ -183,9 +183,9 @@ module Spectrum
       holdings.find { |x| x.holding_id == holding_id }
     end
 
-    # non-HathiTrust Electronic Holdings
+    # non-HathiTrust Electronic Holdings or Digital Holdings
     def elec_holdings
-      holdings.select { |x| x.class.name.to_s.match(/ElectronicHolding/) }
+      holdings.select { |x| ["ELEC", "ALMA_DIGITAL"].any? { |y| x.library == y } }
     end
 
     def physical_holdings?
@@ -230,9 +230,21 @@ module Spectrum
       end
 
       def self.for(holding)
-        [HathiHolding, FindingAid, ElectronicHolding, AlmaHolding].find do |klass|
+        [HathiHolding, FindingAid, ElectronicHolding, DigitalHolding, AlmaHolding].find do |klass|
           klass.match?(holding)
         end.new(holding)
+      end
+    end
+
+    # passes through the data from a Digital Holding
+    class DigitalHolding < Holding
+      def self.match?(holding)
+        holding["library"] == "ALMA_DIGITAL"
+      end
+      ["public_note", "link", "link_text", "delivery_description", "label"].each do |name|
+        define_method(name) do
+          @holding[name]
+        end
       end
     end
 

--- a/local-gems/spectrum-json/lib/spectrum/presenters/electronic_item_presenter.rb
+++ b/local-gems/spectrum-json/lib/spectrum/presenters/electronic_item_presenter.rb
@@ -3,13 +3,17 @@ module Spectrum
     def initialize(item)
       @item = item
     end
+
     def self.for(item)
-      if item.status == 'Not Available'
+      if item.library == "ALMA_DIGITAL"
+        DigitalItem.new(item)
+      elsif item.status == "Not Available"
         UnavailableElectronicItem.new(item)
       else
-        self.new(item)
+        new(item)
       end
     end
+
     def to_a
       [
         link,
@@ -17,24 +21,60 @@ module Spectrum
         {text: note}
       ]
     end
+
     def description
-      @item.description || ''
+      @item.description || ""
     end
+
     def note
-      @item.note || 'N/A'
+      @item.note || "N/A"
     end
+
     def link_text
-      @item.link_text || 'Available online'
+      @item.link_text || "Available online"
     end
+
     def link
-      { text: link_text, href: @item.link}
+      {text: link_text, href: @item.link}
     end
+
     class UnavailableElectronicItem < self
       def link
-        { text: 'Coming soon.' }
+        {text: "Coming soon."}
       end
+
       def description
-        [ 'Link will update when access is available.', @item.description || ''].join(' ').strip 
+        ["Link will update when access is available.", @item.description || ""].join(" ").strip
+      end
+    end
+
+    class DigitalItem
+      def initialize(item)
+        @item = item
+      end
+
+      def source
+        [@item.delivery_description, @item.public_note].compact.join("; ")
+      end
+
+      def link_text
+        @item.link_text || "Available online"
+      end
+
+      def link
+        {text: link_text, href: @item.link}
+      end
+
+      def label
+        @item.label || ""
+      end
+
+      def to_a
+        [
+          link,
+          {text: label},
+          {text: source}
+        ]
       end
     end
   end

--- a/spec/spectrum/bib_record_spec.rb
+++ b/spec/spectrum/bib_record_spec.rb
@@ -1,35 +1,35 @@
 # frozen_string_literal: true
 
-require_relative '../rails_helper'
+require_relative "../rails_helper"
 
 describe Spectrum::BibRecord do
   before(:each) do
-    @solr_bib_alma = File.read('./spec/fixtures/solr_bib_alma.json')
+    @solr_bib_alma = File.read("./spec/fixtures/solr_bib_alma.json")
   end
   subject do
     described_class.new(JSON.parse(@solr_bib_alma))
   end
 
-  context '#mms_id' do
+  context "#mms_id" do
     it "returns a string" do
-      expect(subject.mms_id).to eq('990020578280106381')
+      expect(subject.mms_id).to eq("990020578280106381")
     end
   end
-  #needs to have bib Holdings.
-  context '#holdings' do
+  # needs to have bib Holdings.
+  context "#holdings" do
     it "returns an array" do
-      expect(subject.holdings.class.name).to eq('Array')
+      expect(subject.holdings.class.name).to eq("Array")
     end
     context "alma holding" do
       let(:alma_holding) { subject.holdings.first }
       it "has a library" do
-        expect(alma_holding.library).to eq('HATCH')
+        expect(alma_holding.library).to eq("HATCH")
       end
       it "has a location" do
-        expect(alma_holding.location).to eq('GRAD')
+        expect(alma_holding.location).to eq("GRAD")
       end
       it "has a callnumber" do
-        expect(alma_holding.callnumber).to eq('LB 2331.72 .S371 1990')
+        expect(alma_holding.callnumber).to eq("LB 2331.72 .S371 1990")
       end
       it "has a public_note" do
         expect(alma_holding.public_note).to eq("")
@@ -66,7 +66,7 @@ describe Spectrum::BibRecord do
 
     context "#alma_holding(holding_id)" do
       it "returns the alma holding for a given holding id" do
-        expect(subject.alma_holding("22957681780006381").callnumber).to eq('LB 2331.72 .S371 1990')  
+        expect(subject.alma_holding("22957681780006381").callnumber).to eq("LB 2331.72 .S371 1990")
       end
       it "returns nil for no matching holding" do
         expect(subject.alma_holding("not_a_holding_id")).to be_nil
@@ -74,7 +74,7 @@ describe Spectrum::BibRecord do
     end
     context "an alma holding" do
       let(:alma_holding) { subject.holdings[0] }
-      ['holding_id', 'location', 'callnumber', 'public_note', 'items', 'summary_holdings'].each do |method|
+      ["holding_id", "location", "callnumber", "public_note", "items", "summary_holdings"].each do |method|
         context "##{method}" do
           it "respond_to? #{method}" do
             expect(alma_holding.respond_to?(method)).to be(true)
@@ -83,11 +83,11 @@ describe Spectrum::BibRecord do
       end
     end
     context "an alma item" do
-      let(:alma_item){ subject.holdings[0].items[0] }
-      ['library','location','description','public_note','barcode',
-      'item_policy','process_type','permanent_location','permanent_library',
-      'id','temp_location?','callnumber', 'inventory_number', "item_id", 
-      "fulfillment_unit", "record_has_finding_aid"].each do |method|
+      let(:alma_item) { subject.holdings[0].items[0] }
+      ["library", "location", "description", "public_note", "barcode",
+        "item_policy", "process_type", "permanent_location", "permanent_library",
+        "id", "temp_location?", "callnumber", "inventory_number", "item_id",
+        "fulfillment_unit", "record_has_finding_aid"].each do |method|
         context "##{method}" do
           it "respond_to? #{method}" do
             expect(alma_item.respond_to?(method)).to be(true)
@@ -106,7 +106,7 @@ describe Spectrum::BibRecord do
       end
       context "#item_location_link" do
         it "returns a string" do
-          expect(alma_item.item_location_link).to eq('https://lib.umich.edu/locations-and-hours/hatcher-library')
+          expect(alma_item.item_location_link).to eq("https://lib.umich.edu/locations-and-hours/hatcher-library")
         end
       end
     end
@@ -115,7 +115,7 @@ describe Spectrum::BibRecord do
         expect(subject.physical_holdings?).to eq(true)
       end
       it "returns false for only holdings with library ELEC" do
-        @solr_bib_alma = @solr_bib_alma.gsub(/HATCH/, 'ELEC')
+        @solr_bib_alma = @solr_bib_alma.gsub(/HATCH/, "ELEC")
         expect(subject.physical_holdings?).to eq(false)
       end
     end
@@ -124,7 +124,7 @@ describe Spectrum::BibRecord do
         expect(subject.hathi_holding.class.name.to_s).to eq("Spectrum::BibRecord::HathiHolding")
       end
       it "returns nil for no Hathi Item" do
-        @solr_bib_alma = @solr_bib_alma.gsub(/HathiTrust/, 'SomeOtherTrust')
+        @solr_bib_alma = @solr_bib_alma.gsub(/HathiTrust/, "SomeOtherTrust")
         expect(subject.hathi_holding).to be_nil
       end
     end
@@ -164,7 +164,7 @@ describe Spectrum::BibRecord do
     end
     context "bib record with ELEC holdings" do
       before(:each) do
-        @solr_elec = File.read('./spec/fixtures/solr_elec.json')
+        @solr_elec = File.read("./spec/fixtures/solr_elec.json")
       end
       subject do
         described_class.new(JSON.parse(@solr_elec))
@@ -175,21 +175,31 @@ describe Spectrum::BibRecord do
       it "does not have physical holdings" do
         expect(subject.physical_holdings?).to eq(false)
       end
-      it "returns electronic holdings" do
-        expect(subject.elec_holdings.count).to eq(1)
+      context "#elec_holdings" do
+        it "returns electronic holdings for library ELEC" do
+          expect(subject.elec_holdings.count).to eq(1)
+        end
+        it "returns electronic holdings for library ALMA_DIGITAL" do
+          @solr_elec = @solr_elec.gsub('library\":\"ELEC\"', 'library\":\"ALMA_DIGITAL\"')
+          expect(subject.elec_holdings.count).to eq(1)
+        end
       end
       context "finding_aid" do
-        it "returns nil when no finding_aid" do
+        it "returns nil when finding_aid is false" do
+          expect(subject.finding_aid).to be_nil
+        end
+        it "returns nil when no finding aid" do
+          @solr_elec = @solr_elec.gsub(/finding_aid\\":false,/, "")
           expect(subject.finding_aid).to be_nil
         end
         it "returns holding when there is a finding_aid" do
           @solr_elec = @solr_elec.gsub(/finding_aid\\":false/, "finding_aid\\\":true")
-          expect(subject.finding_aid.class.name).to include('FindingAid')
+          expect(subject.finding_aid.class.name).to include("FindingAid")
         end
       end
       context "electronic holding" do
-        let(:elec_holding){subject.holdings.first}
-        ['link','library','status','link_text','note','description','finding_aid'].each do |method|
+        let(:elec_holding) { subject.holdings.first }
+        ["link", "library", "status", "link_text", "note", "description", "finding_aid"].each do |method|
           context "##{method}" do
             it "respond_to? #{method}" do
               expect(elec_holding.respond_to?(method)).to be(true)
@@ -197,137 +207,131 @@ describe Spectrum::BibRecord do
           end
         end
         it "actually returns the right thing for an element" do
-           expect(elec_holding.status).to eq('Available') 
-
+          expect(elec_holding.status).to eq("Available")
         end
-        
       end
-
     end
-
   end
-  context '#title' do
-    it 'returns a string' do
-      expect(subject.title).to eq('Enhancing faculty careers : strategies for development and renewal /')
+  context "#title" do
+    it "returns a string" do
+      expect(subject.title).to eq("Enhancing faculty careers : strategies for development and renewal /")
     end
   end
 
-  context '#issn' do
-    it 'returns a string' do
-      expect(subject.issn).to eq('')
+  context "#issn" do
+    it "returns a string" do
+      expect(subject.issn).to eq("")
     end
   end
 
-  context '#isbn' do
-    it 'returns a string' do
-      expect(subject.isbn).to eq('9781555422103')
+  context "#isbn" do
+    it "returns a string" do
+      expect(subject.isbn).to eq("9781555422103")
     end
   end
 
-  context '#bib.accession_number' do
-    it 'returns a string' do
-      expect(subject.accession_number).to eq('<accession_number>20758549</accession_number>')
+  context "#bib.accession_number" do
+    it "returns a string" do
+      expect(subject.accession_number).to eq("<accession_number>20758549</accession_number>")
     end
   end
 
-  context '#author' do
-    it 'returns a string' do
-      expect(subject.author).to eq('Schuster, Jack H.')
+  context "#author" do
+    it "returns a string" do
+      expect(subject.author).to eq("Schuster, Jack H.")
     end
   end
 
-  context '#date' do
-    it 'returns a string' do
-      expect(subject.date).to eq('1990')
+  context "#date" do
+    it "returns a string" do
+      expect(subject.date).to eq("1990")
     end
   end
 
-  context '#pub' do
-    it 'returns a string' do
-      expect(subject.pub).to eq('Jossey-Bass Publishers')
+  context "#pub" do
+    it "returns a string" do
+      expect(subject.pub).to eq("Jossey-Bass Publishers")
     end
   end
 
-  context '#place' do
-    it 'returns a string' do
-      expect(subject.place).to eq('San Francisco ')
+  context "#place" do
+    it "returns a string" do
+      expect(subject.place).to eq("San Francisco ")
     end
   end
 
-  context '#edition' do
-    it 'returns a string' do
-      expect(subject.edition).to eq('1st ed.')
+  context "#edition" do
+    it "returns a string" do
+      expect(subject.edition).to eq("1st ed.")
     end
   end
 
-  context '#callnumber' do
-    it 'returns a string' do
-      expect(subject.callnumber).to eq('LB 2331.72 .S371 1990')
+  context "#callnumber" do
+    it "returns a string" do
+      expect(subject.callnumber).to eq("LB 2331.72 .S371 1990")
     end
   end
-  context '#restriction' do
-    it 'returns a string' do
-      expect(subject.restriction).to eq('')
+  context "#restriction" do
+    it "returns a string" do
+      expect(subject.restriction).to eq("")
     end
   end
-  context '#pub_date' do
-    it 'returns a string' do
-      expect(subject.pub_date).to eq('')
+  context "#pub_date" do
+    it "returns a string" do
+      expect(subject.pub_date).to eq("")
     end
   end
-  context '#publisher' do
-    it 'returns a string' do
-      expect(subject.publisher).to eq('San Francisco : Jossey-Bass Publishers, 1990.')
+  context "#publisher" do
+    it "returns a string" do
+      expect(subject.publisher).to eq("San Francisco : Jossey-Bass Publishers, 1990.")
     end
   end
-  context '#physical_description' do
-    it 'returns a string' do
-      expect(subject.physical_description).to eq('xxiv, 346 p. : ill. ; 24 cm')
+  context "#physical_description" do
+    it "returns a string" do
+      expect(subject.physical_description).to eq("xxiv, 346 p. : ill. ; 24 cm")
     end
   end
-  context '#genre' do
-    it 'returns a string' do
+  context "#genre" do
+    it "returns a string" do
       expect(subject.genre).to be_nil
     end
   end
-  context '#sgenre' do
-    it 'returns a string or nil' do
+  context "#sgenre" do
+    it "returns a string or nil" do
       expect(subject.sgenre).to be_nil
     end
   end
-  context '#fmt' do
-    it 'returns a string' do
+  context "#fmt" do
+    it "returns a string" do
       expect(subject.fmt).to eq("")
     end
   end
-  context '#physical_only?' do
-    it 'returns a boolean' do
+  context "#physical_only?" do
+    it "returns a boolean" do
       expect(subject.physical_only?).to eq(true)
     end
   end
-
 end
 
 describe Spectrum::BibRecord::ElectronicHolding do
-
   context "#link" do
-    subject { described_class.new({'link' => url}) }
+    subject { described_class.new({"link" => url}) }
 
     context "When the holding has an Alma link" do
-      let(:url) { 'https://na04.alma.exlibrisgroup.com' }
+      let(:url) { "https://na04.alma.exlibrisgroup.com" }
 
-       it "Returns the Alma link unchanged" do
-          expect(subject.link).to eq(url)
-       end
+      it "Returns the Alma link unchanged" do
+        expect(subject.link).to eq(url)
+      end
     end
 
     context "When the holding has an non-Alma link" do
-      let(:url) { 'https://www.lib.umich.edu' }
+      let(:url) { "https://www.lib.umich.edu" }
       let(:proxied_url) { "https://apps.lib.umich.edu/proxy-login/?url=#{url}" }
 
-       it "Returns the proxied link" do
-          expect(subject.link).to eq(proxied_url)
-       end
+      it "Returns the proxied link" do
+        expect(subject.link).to eq(proxied_url)
+      end
     end
   end
 end

--- a/spec/spectrum/presenters/electronic_item_presenter_spec.rb
+++ b/spec/spectrum/presenters/electronic_item_presenter_spec.rb
@@ -1,28 +1,65 @@
-require_relative '../../rails_helper.rb'
+require_relative "../../rails_helper"
 
-describe  Spectrum::Presenters::ElectronicItem do
-  before(:each) do
-    @item = double(Spectrum::BibRecord::ElectronicHolding, link: 'Link', link_text: 'Link Text', description: 'Description', note: 'Note', status: 'Available')
+describe Spectrum::Presenters::ElectronicItem do
+  context "E56 or 856 electronic item" do
+    before(:each) do
+      @item = instance_double(Spectrum::BibRecord::ElectronicHolding, link: "Link", link_text: "Link Text", description: "Description", note: "Note", status: "Available", library: "ELEC")
+    end
+    subject do
+      described_class.for(@item)
+    end
+    it "returns a regular electronic item when status is 'Available'" do
+      expect(subject.class).to eq(described_class)
+    end
+    it "returns unavailble electronic item when status is 'Not Available'" do
+      allow(@item).to receive(:status).and_return("Not Available")
+      expect(subject.class).to eq(Spectrum::Presenters::ElectronicItem::UnavailableElectronicItem)
+    end
+    it "has appropriate available item #to_a" do
+      expect(subject.to_a).to eq([{text: "Link Text", href: "Link"}, {text: "Description"}, {text: "Note"}])
+    end
+    it "has appropriate unavailable item #to_a" do
+      allow(@item).to receive(:status).and_return("Not Available")
+      expect(subject.to_a).to eq(
+        [
+          {text: "Coming soon."},
+          {text: "Link will update when access is available. Description"},
+          {text: "Note"}
+        ]
+      )
+    end
   end
-  subject do
-    described_class.for(@item)
-  end
-  it "returns a regular electronic item is status is 'Available'" do
-    expect(subject.class).to eq(described_class)
-  end
-  it "returns unavailble electronic item when status is 'Not Available'" do
-    allow(@item).to receive(:status).and_return('Not Available')
-    expect(subject.class).to eq(Spectrum::Presenters::ElectronicItem::UnavailableElectronicItem)
-  end
-  it "has appropriate available item #to_a" do
-    expect(subject.to_a).to eq([{text: 'Link Text', href: 'Link'},{text: 'Description'},{text: 'Note'}])
-  end
-  it "has appropriate unavailable item #to_a" do
-    allow(@item).to receive(:status).and_return('Not Available')
-    expect(subject.to_a).to eq(
-      [
-        {text: 'Coming soon.'},
-        {text: 'Link will update when access is available. Description'},
-        {text: 'Note'}])
+  context "Alma Digital electronic item" do
+    before(:each) do
+      @item = instance_double(Spectrum::BibRecord::DigitalHolding, link: "Link", link_text: "Link text", library: "ALMA_DIGITAL", public_note: "Public note", delivery_description: "Delivery description", label: "Label")
+    end
+    subject do
+      described_class.for(@item)
+    end
+    it "returns a digital electronic item present when library is ALMA Digital" do
+      expect(subject.class).to eq(Spectrum::Presenters::ElectronicItem::DigitalItem)
+    end
+    it "has appropriate digital item #to_a" do
+      expect(subject.to_a).to eq([
+        {text: "Link text", href: "Link"},
+        {text: "Label"},
+        {text: "Delivery description; Public note"}
+      ])
+    end
+    context "source" do
+      it "handles empty public note" do
+        allow(@item).to receive(:public_note).and_return(nil)
+        expect(subject.source).to eq("Delivery description")
+      end
+      it "handles nil delivery_description" do
+        allow(@item).to receive(:delivery_description).and_return(nil)
+        expect(subject.source).to eq("Public note")
+      end
+      it "handles both nil public note and delivery description" do
+        allow(@item).to receive(:public_note).and_return(nil)
+        allow(@item).to receive(:delivery_description).and_return(nil)
+        expect(subject.source).to eq("")
+      end
+    end
   end
 end


### PR DESCRIPTION
Solr will produce a holding with the library ALMA_DIGITAL for Alma Digital items. These items will have the fields described in the Spectrum::BibRecord::DigitalHolding class. They are presented as if they are Electronic Holdings so are a flavor of the ElectronicItemPresenter.

This is not related to a LIBSEARCH issue. It comes out of a meeting I was in with the Alma Digital team. 