### PR TITLE
[LIBSEARCH-898] Add Retracted metadata to brief and medium view Articles records

### DIFF
--- a/config/fields.yml
+++ b/config/fields.yml
@@ -3986,6 +3986,14 @@
       fields: []
       name: href
   metadata_component:
+     preview:
+      type: structured_data_href_linked
+      href_field: href
+      text_field: text
+     medium:
+      type: structured_data_href_linked
+      href_field: href
+      text_field: text
      full:
       type: structured_data_href_linked
       href_field: href

--- a/spec/spectrum-config/search_engines/primo/engine_spec.rb
+++ b/spec/spectrum-config/search_engines/primo/engine_spec.rb
@@ -1,9 +1,9 @@
-require_relative '../../../rails_helper'
-require 'spectrum/search_engines/primo/engine'
+require_relative "../../../rails_helper"
+require "spectrum/search_engines/primo/engine"
 
 describe Spectrum::SearchEngines::Primo::Engine do
   context "#query" do
-    subject { described_class.new(key: "KEY", host: 'HOST') }
+    subject { described_class.new(key: "KEY", host: "HOST", libkey: {}) }
     it "takes this form" do
       expect(subject.query).to eq("apikey=KEY&scope=default_scope&tab=default_tab&vid=Auto1")
     end


### PR DESCRIPTION
> Add the Retraction metadata element to brief and medium view Articles records, as noted in the [metadata spec](https://docs.google.com/spreadsheets/d/1qk13TMdSYHR8RBiXwZJV9I220VZKMdUjsFsjmx3bX48/edit#gid=1491578089).