### PR TITLE
Bug: `LC Subject starts with` switches to `Keyword` in search

### DIFF
--- a/app/models/spectrum/search_engines/solr.rb
+++ b/app/models/spectrum/search_engines/solr.rb
@@ -412,6 +412,16 @@ module Spectrum
           end
         end
 
+        if fields.include?('lc_subject_starts_with')
+          config.add_search_field('lc_subject_starts_with') do |field|
+            field.show_in_dropdown = true
+            field.solr_local_parameters = {
+              qf: 'lc_subject_starts_with_txt',
+              pf: 'lc_subject_starts_with_txt'
+            }
+          end
+        end
+
         if fields.include?('call_number')
           config.add_search_field('call_number') do |field|
             field.show_in_dropdown = true

--- a/config/fields.yml
+++ b/config/fields.yml
@@ -3750,6 +3750,11 @@
   metadata:
     name: Browse title starts with
 
+- id: lc_subject_starts_with
+  query_field: search_lc_subject_starts_with
+  metadata:
+    name: LC Subject starts with
+
 - id: call_number_starts_with
   query_field: search_call_number_starts_with
   metadata:

--- a/config/foci/00-catalog.yml
+++ b/config/foci/00-catalog.yml
@@ -265,6 +265,7 @@ fields:
 # Search specific fields
   - title_starts_with
   - call_number_starts_with
+  - lc_subject_starts_with
   - subject
   - isn
 # Citation specfic fields, not for display

--- a/config/search_field.yml
+++ b/config/search_field.yml
@@ -84,6 +84,12 @@
     qf: issn_txt
     pf: issn_txt
 
+- name: lc_subject_starts_with
+  dropdown: true
+  local_parameters:
+    qf: lc_subject_starts_with_txt
+    pf: lc_subject_starts_with_txt
+
 - name: call_number
   dropdown: true
   local_parameters:

--- a/local-gems/spectrum-json/lib/spectrum/field_tree/field.rb
+++ b/local-gems/spectrum-json/lib/spectrum/field_tree/field.rb
@@ -13,6 +13,7 @@ module Spectrum
 
       PHRASE_ONLY_FIELDS = %w[
           search_call_number_starts_with
+          search_lc_subject_starts_with
           search_title_starts_with
       ]
 

--- a/spec/spectrum-config/search_engines/primo/engine_spec.rb
+++ b/spec/spectrum-config/search_engines/primo/engine_spec.rb
@@ -1,9 +1,9 @@
-require_relative '../../../rails_helper'
-require 'spectrum/search_engines/primo/engine'
+require_relative "../../../rails_helper"
+require "spectrum/search_engines/primo/engine"
 
 describe Spectrum::SearchEngines::Primo::Engine do
   context "#query" do
-    subject { described_class.new(key: "KEY", host: 'HOST') }
+    subject { described_class.new(key: "KEY", host: "HOST", libkey: {}) }
     it "takes this form" do
       expect(subject.query).to eq("apikey=KEY&scope=default_scope&tab=default_tab&vid=Auto1")
     end


### PR DESCRIPTION
When searching in Catalog by [LC Subject starts with](https://search.lib.umich.edu/catalog?library=All+libraries&query=lc_subject_starts_with%3A(Human+rights)), the search field defaults to `Keyword`. This is because `LC Subject starts with` is not included in the list of fields for the `mirlyn` datastore:
![Screenshot 2023-08-08 at 10 53 55 AM](https://github.com/mlibrary/spectrum/assets/27687379/bc96d861-1c28-40ed-9608-786d61a3aadd)

This pull request adds the necessary information to add `LC Subject starts with` to the list of `fields`.