### PR TITLE
Fix bug where item is checked out before indexing

### DIFF
--- a/spec/spectrum/decorators/physical_item_decorator_spec.rb
+++ b/spec/spectrum/decorators/physical_item_decorator_spec.rb
@@ -414,12 +414,12 @@ describe Spectrum::Decorators::PhysicalItemDecorator do
       allow(@input[:solr_item]).to receive(:process_type).and_return("LOAN")
       allow(@input[:solr_item]).to receive(:library).and_return("HATCH")
       allow(@input[:solr_item]).to receive(:location).and_return("GRAD")
-      @input[:alma_loan] = "not_nil"
+      @input[:alma_loan] = {"process_status" => "LOAN"}
       expect(subject.recallable?).to eq(true)
     end
     it "is false for reserve item that's in process" do
       allow(@input[:solr_item]).to receive(:process_type).and_return("LOAN")
-      @input[:alma_loan] = "not_nil"
+      @input[:alma_loan] = {"process_status" => "LOAN"}
       allow(@input[:solr_item]).to receive(:library).and_return("HATCH")
       allow(@input[:solr_item]).to receive(:location).and_return("RESC")
       expect(subject.recallable?).to eq(false)

--- a/spec/spectrum/entities/alma_item_spec.rb
+++ b/spec/spectrum/entities/alma_item_spec.rb
@@ -134,6 +134,12 @@ describe Spectrum::Entities::AlmaItem do
       expect(subject.process_type).to eq(nil)
     end
   end
+  context "item is checked out today" do
+    it "returns the due date" do
+      @alma_loan["process_status"] = "LOAN"
+      expect(subject.process_type).to eq("LOAN")
+    end
+  end
   context "item is lost" do
     it "returns lost process type if item is lost" do
       @alma_loan["process_status"] = "LOST"


### PR DESCRIPTION
Holdings code used to only handle having up to date information on items checked in before indexing. Now it also handles items checked out before indexing. 