### PR TITLE
Libsearch 774 catalog published

### DIFF
--- a/config/fields.yml
+++ b/config/fields.yml
@@ -3600,67 +3600,71 @@
       marc:
         aggregator: labeling
         fields:
-          - label: ab
+          - label: abc
             tag: "260"
-            sub: '[ab]'
+            sub: '[abc]'
             join: ' '
-          - label: c
-            tag: "260"
-            sub: "[c]"
     - type: marcxml
       field: fullrecord
       marc:
         aggregator: labeling
         fields:
-          - label: ab
+          - label: abc
             tag: "880"
-            sub: "[ab]"
+            sub: "[abc]"
             join: ' '
             where:
               - sub: "6"
                 start_with: ['260']
-          - label: c
+              - sub: '6'
+                not_end_with: ['/', '/r']
+          - label: abc
             tag: "880"
-            sub: "[c]"
+            sub: "[abc]"
             join: ' '
+            prepend: "\u2067"
+            append: "\u2069"
             where:
               - sub: "6"
                 start_with: ['260']
+              - sub: "6"
+                end_with: ['/', '/r']
     - type: marcxml
       field: fullrecord
       marc:
         aggregator: labeling
         fields:
-          - label: ab
+          - label: abc
             tag: '264'
             ind2: '1'
-            sub: '[ab]'
+            sub: '[abc]'
             join: ' '
-          - label: c
-            tag: '264'
-            ind2: '1'
-            sub: '[c]'
     - type: marcxml
       field: fullrecord
       marc:
         aggregator: labeling
         fields:
-          - label: ab
+          - label: abc
             tag: '880'
-            sub: '[ab]'
+            sub: '[abc]'
             ind2: '1'
             join: ' '
             where:
               - sub: '6'
                 start_with: ['264']
-          - label: c
-            tag: '880'
-            sub: '[c]'
-            ind2: '1'
+              - sub: '6'
+                not_end_with: ['/', '/r']
+          - label: abc
+            tag: "880"
+            sub: "[abc]"
             join: ' '
+            prepend: "\u2067"
+            append: "\u2069"
             where:
               - sub: '6'
                 start_with: ['264']
+              - sub: "6"
+                end_with: ['/', '/r']
   metadata_component:
     medium:
       type: plain

--- a/config/fields.yml
+++ b/config/fields.yml
@@ -3622,8 +3622,8 @@
             tag: "880"
             sub: "[abc]"
             join: ' '
-            prepend: "\u2067"
-            append: "\u2069"
+            prefix: "\u2067"
+            suffix: "\u2069"
             where:
               - sub: "6"
                 start_with: ['260']
@@ -3658,8 +3658,8 @@
             tag: "880"
             sub: "[abc]"
             join: ' '
-            prepend: "\u2067"
-            append: "\u2069"
+            prefix: "\u2067"
+            suffix: "\u2069"
             where:
               - sub: '6'
                 start_with: ['264']

--- a/local-gems/spectrum-config/lib/spectrum/config.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config.rb
@@ -85,6 +85,8 @@ require 'spectrum/config/marc_matcher_where_is'
 require 'spectrum/config/marc_matcher_where_not'
 require 'spectrum/config/marc_matcher_where_exists'
 require 'spectrum/config/marc_matcher_where_start_with'
+require 'spectrum/config/marc_matcher_where_end_with'
+require 'spectrum/config/marc_matcher_where_not_end_with'
 require 'spectrum/config/marc_matcher_where'
 
 require 'spectrum/config/marc'

--- a/local-gems/spectrum-config/lib/spectrum/config/formatted_catalog_published_field.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/formatted_catalog_published_field.rb
@@ -38,12 +38,7 @@ module Spectrum
           values = [group.value(data)].flatten(1).reject do |item|
             item.nil? || item.empty?
           end.map do |item|
-            [
-              (item.find {|fl| fl[:uid] == 'ab'} || {})[:value],
-              date_val || (item.find {|fl| fl[:uid] == 'c'} || {})[:value]
-            ].flatten.reject do |val|
-              val.nil? || !(String === val) || val.empty?
-            end.join(' ')
+            (item.find { |fl| fl[:uid] == 'abc' } || {})[:value]
           end
           values.empty? ? nil : values
         end.compact.flatten

--- a/local-gems/spectrum-config/lib/spectrum/config/labeling_aggregator.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/labeling_aggregator.rb
@@ -15,12 +15,12 @@ module Spectrum
           metadata_values.map do |metadata, values|
             label = metadata[:label]
             join = metadata[:join]
-            value_append = metadata[:append] || ''
-            value_prepend = metadata[:prepend] || ''
+            prefix = metadata[:prefix] || ''
+            suffix = metadata[:suffix] || ''
             value = if join
-              value_prepend + values.join(join) + value_append
+              prefix + values.join(join) + suffix
             else
-              values.map { |val| value_prepend + val + value_append }
+              values.map { |val| prefix + val + suffix }
             end
 
             {

--- a/local-gems/spectrum-config/lib/spectrum/config/labeling_aggregator.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/labeling_aggregator.rb
@@ -6,25 +6,27 @@ module Spectrum
 
       def add(metadata, field, subfield)
         @ret[field] ||= {}
-        @ret[field][metadata[:label]] ||= {}
-        @ret[field][metadata[:label]][metadata[:join]] ||= []
-        @ret[field][metadata[:label]][metadata[:join]] << subfield.value
+        @ret[field][metadata] ||= []
+        @ret[field][metadata] << subfield.value
       end
 
       def to_value
-        @ret.values.map do |labelled_fields|
-          labelled_fields.map do |joined_fields|
-            join = joined_fields[1].keys.first
-            values = joined_fields[1].values.first
-            joined_fields[1] = if join
-                                 values.join(join)
-                               else
-                                 values
-                               end
+        @ret.values.map do |metadata_values|
+          metadata_values.map do |metadata, values|
+            label = metadata[:label]
+            join = metadata[:join]
+            value_append = metadata[:append] || ''
+            value_prepend = metadata[:prepend] || ''
+            value = if join
+              value_prepend + values.join(join) + value_append
+            else
+              values.map { |val| value_prepend + val + value_append }
+            end
+
             {
-              uid: joined_fields[0],
-              name: joined_fields[0],
-              value: joined_fields[1],
+              uid: label,
+              name: label,
+              value: value,
               value_has_html: true
             }
           end

--- a/local-gems/spectrum-config/lib/spectrum/config/marc_matcher.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/marc_matcher.rb
@@ -2,13 +2,15 @@
 module Spectrum
   module Config
     class MarcMatcher
-      attr_reader :label, :join, :filters, :default
+      attr_reader :label, :join, :filters, :default, :prefix, :suffix
 
       def metadata
         {
           label: label,
           join: join,
           filters: filters,
+          prefix: prefix,
+          suffix: suffix,
         }
       end
 
@@ -16,6 +18,8 @@ module Spectrum
         @label = arg['label'] || "#{arg['tag']} #{arg['ind1']}#{arg['ind2']} #{arg['sub']}"
         @join  = arg['join']
         @filters = (arg['filters'] || []).map(&:symbolize_keys)
+        @prefix = arg['prefix'] || ''
+        @suffix = arg['suffix'] || ''
         @tag   = /#{arg['tag'] || '.'}/
         @sub   = /#{arg['sub'] || '.'}/
         @ind1  = /#{arg['ind1'] || '.'}/

--- a/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_end_with.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_end_with.rb
@@ -1,0 +1,19 @@
+module Spectrum
+  module Config
+    class MarcMatcherWhereEndWith < MarcMatcherWhereClause
+      attr_accessor :sub, :values
+      type 'end_with'
+
+      def initialize(cfg)
+        cfg ||= {}
+        self.sub = /#{cfg['sub']}/
+        self.values = cfg['end_with']
+      end
+
+      def match?(field)
+        return true unless sub && values
+        !find_all(field).reject { |subfield| !values.any? { |val| subfield.value.end_with?(val) } }.empty?
+      end
+    end
+  end
+end

--- a/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_not_end_with.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_not_end_with.rb
@@ -1,0 +1,19 @@
+module Spectrum
+  module Config
+    class MarcMatcherWhereNotEndWith < MarcMatcherWhereClause
+      attr_accessor :sub, :values
+      type 'not_end_with'
+
+      def initialize(cfg)
+        cfg ||= {}
+        self.sub = /#{cfg['sub']}/
+        self.values = cfg['not_end_with']
+      end
+
+      def match?(field)
+        return true unless sub && values
+        find_all(field).reject { |subfield| !values.any? { |val| subfield.value.end_with?(val) } }.empty?
+      end
+    end
+  end
+end

--- a/spec/data/formatted_catalog_published_field/args-001.json
+++ b/spec/data/formatted_catalog_published_field/args-001.json
@@ -10,14 +10,9 @@
         "aggregator": "labeling",
         "fields": [
           {
-            "label": "c",
+            "label": "abc",
             "tag": "260",
-            "sub": "[c]"
-          },
-          {
-            "label": "ab",
-            "tag": "260",
-            "sub": "[ab]",
+            "sub": "[abc]",
             "join": " "
           }
         ]
@@ -30,16 +25,10 @@
         "aggregator": "labeling",
         "fields": [
           {
-            "label": "c",
+            "label": "abc",
             "tag": "264",
             "ind1": "1",
-            "sub": "[c]"
-          },
-          {
-            "label": "ab",
-            "tag": "260",
-            "ind1": "1",
-            "sub": "[ab]",
+            "sub": "[abc]",
             "join": " "
           }
         ]

--- a/spec/data/formatted_catalog_published_field/results-001.json
+++ b/spec/data/formatted_catalog_published_field/results-001.json
@@ -1,1 +1,1 @@
-["Moskva : Izd-vo Akademii nauk SSSR, 1936","Москва : Изд-во Академии наук СССР, 1936","Moskva : Izdatelʹstvo \"Nauka\" 1936","Leningrad : Izdatelʹstvo \"Nauka\" 1936"]
+["Moskva : Izd-vo Akademii nauk SSSR, 1936-<1989>","Москва : Изд-во Академии наук СССР, 1936-<1989>","Moskva : Izdatelʹstvo \"Nauka\"","Leningrad : Izdatelʹstvo \"Nauka\""]

--- a/spec/spectrum-config/spectrum/config/marc_matcher_spec.rb
+++ b/spec/spectrum-config/spectrum/config/marc_matcher_spec.rb
@@ -7,7 +7,7 @@ describe Spectrum::Config::MarcMatcher do
     context "When configured with an empty hash" do
       let(:cfg) {{}}
       subject { described_class.new(cfg) }
-      let(:results) {{ label: "  ", join: nil, filters: [] }}
+      let(:results) {{ label: "  ", join: nil, filters: [], prefix: '', suffix: '' }}
 
       it "returns appropriate defaults" do
         expect(subject.metadata).to eq(results)
@@ -21,7 +21,9 @@ describe Spectrum::Config::MarcMatcher do
         {
           label: 'LABEL',
           join:  'JOIN',
-          filters: [{attr: 'FILTER_ATTR'}]
+          filters: [{attr: 'FILTER_ATTR'}],
+          prefix: '',
+          suffix: '',
         }
       end
 


### PR DESCRIPTION
Fixes for supporting bidirectional text in the catalog's published field.

These changes insert unicode characters at the beginning  and the ending of the field values when the field is in a left-to-right language.