### PR TITLE
Add `utm_source` query parameter to external links.

### DIFF
--- a/local-gems/spectrum-config/lib/spectrum/config/primo_resource_access_field.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/primo_resource_access_field.rb
@@ -114,7 +114,8 @@ module Spectrum
           query: {
             DocumentID: "https://search.lib.umich.edu/primo/record/#{data['id']}",
             LinkModel: 'unknown',
-            ReportSource: 'ArticlesSearch-LibKey-GoToPDF'
+            ReportSource: 'ArticlesSearch-LibKey-GoToPDF',
+            utm_source: 'library-search'
           }.to_query
         ).to_s
       end
@@ -127,7 +128,8 @@ module Spectrum
           query: {
             DocumentID: "https://search.lib.umich.edu/primo/record/#{data['id']}",
             LinkModel: 'unknown',
-            ReportSource: 'ArticlesSearch'
+            ReportSource: 'ArticlesSearch',
+            utm_source: 'library-search'
           }.to_query
         ).to_s
       end

--- a/local-gems/spectrum-config/lib/spectrum/config/summon_resource_access_field.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/summon_resource_access_field.rb
@@ -91,7 +91,8 @@ module Spectrum
           query: {
             DocumentID: "https://search.lib.umich.edu/articles/record/#{data.id}",
             LinkModel: 'unknown',
-            ReportSource: 'ArticlesSearch'
+            ReportSource: 'ArticlesSearch',
+            utm_source: 'library-search'
           }.to_query
         ).to_s
       end


### PR DESCRIPTION
# Overview
For analytics tracking of external links coming from Search, the query parameter `utm_source=library-search` needed to be added.

The only remaining external links that do not have the query param on Search are the"Report a problem" links. This pull request adds it.