### PR TITLE
LIBSEARCH-894: Bug fix relating to MarcMatcherWhereClause(s).

### DIFF
--- a/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_end_with.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_end_with.rb
@@ -12,7 +12,7 @@ module Spectrum
 
       def match?(field)
         return true unless sub && values
-        !find_all(field).reject { |subfield| !values.any? { |val| subfield.value.end_with?(val) } }.empty?
+        find_all(field).any? { |subfield| values.any? { |val| subfield.value.end_with?(val) } }
       end
     end
   end

--- a/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_is.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_is.rb
@@ -12,7 +12,7 @@ module Spectrum
 
       def match?(field)
         return true unless sub && values
-        !find_all(field).reject { |subfield| !values.include?(subfield.value) }.empty?
+        find_all(field).any? { |subfield| values.include?(subfield.value) }
       end
     end
   end

--- a/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_not.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_not.rb
@@ -12,7 +12,7 @@ module Spectrum
 
       def match?(field)
         return true unless sub && values
-        find_all(field).empty?
+        find_all(field).all? { |subfield| !values.include?(subfield.value) }
       end
 
     end

--- a/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_not_end_with.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_not_end_with.rb
@@ -12,7 +12,7 @@ module Spectrum
 
       def match?(field)
         return true unless sub && values
-        find_all(field).reject { |subfield| !values.any? { |val| subfield.value.end_with?(val) } }.empty?
+        find_all(field).all? { |subfield| !values.any? { |val| subfield.value.end_with?(val) } }
       end
     end
   end

--- a/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_start_with.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_start_with.rb
@@ -12,7 +12,7 @@ module Spectrum
 
       def match?(field)
         return true unless sub && values
-        !find_all(field).reject { |subfield| !values.any? { |val| subfield.value.start_with?(val) } }.empty?
+        find_all(field).any? { |subfield| values.any? { |val| subfield.value.start_with?(val) } }
       end
     end
   end

--- a/spec/spectrum-config/spectrum/config/marc_matcher_where_is_spec.rb
+++ b/spec/spectrum-config/spectrum/config/marc_matcher_where_is_spec.rb
@@ -30,14 +30,19 @@ describe Spectrum::Config::MarcMatcherWhereIs do
     let(:cfg) { {'sub' => 'a', 'is' => ['']} }
     let(:matching_field) { FieldStub.new('a', '') }
     let(:not_matching_field) { FieldStub.new('b', '') }
+    let(:not_matching_value) { FieldStub.new('a', 'not-value') }
       
     context "#match?" do
-      it 'returns true when given match' do
+      it 'returns true when given matching field and value' do
         expect(subject.match?(matching_field)).to be(true)
       end
 
-      it 'returns false when given not-match' do
+      it 'returns false when given not-matching field with matching value' do
         expect(subject.match?(not_matching_field)).to be(false)
+      end
+
+      it 'returns false when given matching field and not-matching value' do
+        expect(subject.match?(not_matching_value)).to be(false)
       end
     end
   end

--- a/spec/spectrum-config/spectrum/config/marc_matcher_where_not_spec.rb
+++ b/spec/spectrum-config/spectrum/config/marc_matcher_where_not_spec.rb
@@ -30,14 +30,19 @@ describe Spectrum::Config::MarcMatcherWhereNot do
     let(:cfg) { {'sub' => 'a', 'not' => ['']} }
     let(:matching_field) { FieldStub.new('a', '') }
     let(:not_matching_field) { FieldStub.new('b', '') }
+    let(:not_matching_value) { FieldStub.new('a', 'not-value') }
       
     context "#match?" do
-      it 'returns true when given match' do
+      it 'returns false when given the thing to not match' do
         expect(subject.match?(matching_field)).to be(false)
       end
 
-      it 'returns false when given not-match' do
+      it 'returns true when not given the field to not-match' do
         expect(subject.match?(not_matching_field)).to be(true)
+      end
+
+      it 'returns true when given the field to not-match with a different value' do
+        expect(subject.match?(not_matching_value)).to be(true)
       end
     end
   end


### PR DESCRIPTION
Bug was with MarchMatcherWhereNot.  It was matching too many things. The logic for all of these clauses were simplified. New tests were introduced to confirm the bug fix is working.