### PR TITLE
Fixes for Database 'title_starts_with' searches.

### DIFF
--- a/config/foci/00-catalog.yml
+++ b/config/foci/00-catalog.yml
@@ -6,6 +6,7 @@ metadata:
 source: mirlyn
 
 new_parser: true
+transformer: MLibrarySearchParser::Transformer::Solr::LocalParams
 search_field_default: all_fields
 search_attr_defaults:
   mm: $default_mm

--- a/config/foci/02-databases.yml
+++ b/config/foci/02-databases.yml
@@ -4,6 +4,8 @@ metadata:
   name: Databases
   short_desc: "Search for databases"
 source: website
+new_parser: true
+transformer: MLibrarySearchParser::Transformer::Solr::SometimesQuotedLocalParams
 highly_recommended:
   field: academic_discipline
   sort_uid: title_asc
@@ -11,6 +13,12 @@ highly_recommended:
 href:
   field: path_alias
   prefix: http://www.lib.umich.edu/node/
+
+search_field_default: all_fields
+search_attr_defaults:
+  mm: $default_mm
+  mm.autoRelax: $mm.autoRelax
+  tie: $tie
 
 solr_params:
   # title
@@ -37,7 +45,7 @@ solr_params:
 
   # isn
   f.search_isn.qf: issn
-  f.search_isn.qf: ""
+  f.search_isn.pf: issn
   f.search_isn.mm: 100%
 
   # publisher
@@ -52,7 +60,40 @@ solr_params:
   pf: title all_titles content
   tie: 0.1
   defType: edismax
-  
+
+search_fields:
+  title:
+    qf: sort_title^12 stitle^12 title_unstemmed^6 all_titles_unstemmed^3 title^2 alt^1
+    pf: title alt
+    mm: 75%
+
+  title_starts_with:
+    pf: title_ngram
+    qf: title_ngram
+    mm: 100%
+  publisher:
+    qf: pvc_text
+    pf: pvc_text
+    mm: 50%
+  isn:
+    qf: issn
+    pf: issn
+    mm: 100%
+  academic_discipline:
+    qf: og_groups_both^5 tmfield_taxonomy_name
+    pf: og_groups_both^5 tmfield_taxonomy_name
+    mm: 50%
+
+  all_fields:
+    qf: title_unstemmed^10 title^7 all_titles_unstemmed^8 all_titles^6 issn^10 content^2
+    pf: title all_titles content
+    mm: 25%
+
+  allfields:
+    qf: title_unstemmed^10 title^7 all_titles_unstemmed^8 all_titles^6 issn^10 content^2
+    pf: title all_titles content
+    mm: 25%
+
 filters:
   - "+source:searchtools-drupal"
   - "+status:true"

--- a/config/foci/03-journals.yml
+++ b/config/foci/03-journals.yml
@@ -5,6 +5,7 @@ metadata:
   name: Online Journals
   short_desc: "Search for online journals."
 source: website
+transformer: MLibrarySearchParser::Transformer::Solr::LocalParams
 filters:
   - "+source:ejournals-mirlyn"
 highly_recommended:

--- a/config/foci/03-onlinejournals.yml
+++ b/config/foci/03-onlinejournals.yml
@@ -8,6 +8,7 @@ highly_recommended:
   field: academic_discipline
   sort_uid: title_asc
   suffix: _bb
+transformer: MLibrarySearchParser::Transformer::Solr::LocalParams
 solr_params:
 
   f.search_series.pf: series^500 series2^50

--- a/config/foci/04-website.yml
+++ b/config/foci/04-website.yml
@@ -5,6 +5,7 @@ metadata:
   short_desc: "Search the for Guides and more."
 source: website
 # https://stackoverflow.com/questions/20217686/multiple-boost-queries-in-solr
+transformer: MLibrarySearchParser::Transformer::Solr::LocalParams
 solr_params:
   # default
   qt: edismax

--- a/config/foci/05-primo-articles.yml
+++ b/config/foci/05-primo-articles.yml
@@ -13,6 +13,7 @@ sorts:
 #  title: primo_title
 #  author: primo_author
 new_parser: true
+transformer: MLibrarySearchParser::Transformer::Solr::LocalParams
 search_fields:
   all_fields:
     pf: .

--- a/local-gems/spectrum-config/lib/spectrum/config/focus.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/focus.rb
@@ -9,7 +9,8 @@ module Spectrum
                     :placeholder, :warning, :description,
                     :category, :base,
                     :fields, :url, :filters, :sorts, :id_field, :solr_params,
-                    :highly_recommended, :base_url, :raw_config, :default_sort
+                    :highly_recommended, :base_url, :raw_config, :default_sort,
+                    :transformer
 
 
       HREF_DATA = {
@@ -113,6 +114,7 @@ module Spectrum
         @get_null_facets = nil
         @hierarchy       = Hierarchy.new(args['hierarchy']) if args['hierarchy']
         @new_parser      = args['new_parser']
+        @transformer     = args['transformer']&.constantize
         @highly_recommended = HighlyRecommended.new(args['highly_recommended'])
         @facet_values    = {}
       end

--- a/local-gems/spectrum-json/lib/mlibrary_search_parser/transformer/solr/sometimes_quoted_local_params.rb
+++ b/local-gems/spectrum-json/lib/mlibrary_search_parser/transformer/solr/sometimes_quoted_local_params.rb
@@ -1,0 +1,51 @@
+module MLibrarySearchParser
+  module Transformer
+    module Solr
+      class SometimesQuotedLocalParams < LocalParams
+        # @override
+        # @param [MLibrarySearchParser::Node::BaseNode] node
+        def edismaxify(field, node)
+          q_localparams_name = "q#{node.number}"
+          qq_localparams_name = "qq#{node.number}"
+          tokens_name = "t#{node.number}"
+
+          set_param(q_localparams_name, node.clean_string)
+          set_param(qq_localparams_name, lucene_escape(node.tokens_phrase))
+          set_param(tokens_name, lucene_escape(node.wanted_tokens_string))
+
+          attributes = field_config(field)
+          args = attributes.keys.each_with_object({}) do |k, h|
+            v = attributes[k]
+            fname = "#{field}_#{k}"
+            v = v.to_s
+            v = v.to_s.gsub(/\$q\b/, "$" + q_localparams_name)
+            v = v.gsub(/\$qq\b/, "$" + qq_localparams_name)
+            v = v.gsub(/\$t\b/, "$" + tokens_name)
+            v = v.gsub(/[\n\s]+/, " ")
+            set_param(fname, v)
+            h[k] = "$#{fname}"
+          end
+
+          args = default_attributes.merge(args)
+
+          # If the node is a boolean, we need to get rid of the mm parameter
+          # because edismax with bools and mm just don't play well together.
+          #
+          # See https://blog.innoventsolutions.com/innovent-solutions-blog/2017/02/solr-edismax-boolean-query.html
+          # and/or SOLR-8812
+
+          if [:and, :or].include? node.node_type
+            args.delete("mm")
+          end
+          arg_pairs = args.each_pair.map { |k, v| "#{k}=#{v}" }
+
+          if field == "title_starts_with"
+            "{!edismax #{arg_pairs.join(" ")} v=$#{qq_localparams_name}}"
+          else
+            "{!edismax #{arg_pairs.join(" ")} v=$#{q_localparams_name}}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/local-gems/spectrum-json/lib/spectrum/json.rb
+++ b/local-gems/spectrum-json/lib/spectrum/json.rb
@@ -4,6 +4,8 @@ require "rails" # so `bundle console` works
 require "json-schema"
 require "lru_redux"
 require "alma_rest_client"
+require "mlibrary_search_parser"
+require "mlibrary_search_parser/transformer/solr/sometimes_quoted_local_params"
 
 require "active_support"
 require "active_support/concern"

--- a/local-gems/spectrum-json/lib/spectrum/request/requesty.rb
+++ b/local-gems/spectrum-json/lib/spectrum/request/requesty.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'mlibrary_search_parser'
-
 module Spectrum
   module Request
     module Requesty
@@ -187,7 +185,7 @@ module Spectrum
 
 
       def new_parser_query(query_map = {}, filter_map = {}, built_search = @psearch)
-        lp = MLibrarySearchParser::Transformer::Solr::LocalParams.new(built_search)
+        lp = @focus.transformer.new(built_search)
         base_query(query_map, filter_map).merge(lp.params)
       end
 
@@ -213,7 +211,7 @@ module Spectrum
       end
 
       def query(query_map = {}, filter_map = {})
-        if @is_new_parser
+        if @is_new_parser && @psearch
           new_parser_query(query_map, filter_map)
         else
           tree_query(query_map, filter_map)


### PR DESCRIPTION
* Provide an alternative MLibrarySearchParser::Transformer::Solr:: LocalParams class which looks for quoted inputs on title_starts_with fielded searches.
* Allow (require) the transformer to be specified in the DataStore config.
* Update The DataStore (Focus class) to store the transformer.
* Update Spectrum::Request::Requesty to use the transformer named in the DataSto re.