### PR TITLE
LIBSEARCH 939 Get This on an item with "unavailable" barcode never loads request options

### DIFF
--- a/local-gems/spectrum-json/lib/spectrum/empty_item_holding.rb
+++ b/local-gems/spectrum-json/lib/spectrum/empty_item_holding.rb
@@ -37,7 +37,7 @@ module Spectrum
 
     # Things that respond with true
     [:closed_stacks?, :can_request?, :mobile?, :off_shelf?,
-      :ann_arbor?, :not_on_shelf?, :not_reservable_library?].each do |name|
+      :ann_arbor?, :not_on_shelf?, :not_game?, :not_reservable_library?].each do |name|
       define_method(name) do
         true
       end


### PR DESCRIPTION
Needed to add the method `not_game?` to the `EmptyItemHolding`.
