### PR TITLE
LIBSEARCH 961 and 973 ILLiad Get This form changes

### DIFF
--- a/local-gems/spectrum-json/lib/spectrum/bib_record.rb
+++ b/local-gems/spectrum-json/lib/spectrum/bib_record.rb
@@ -89,14 +89,20 @@ module Spectrum
       fetch_joined("oclc", ",")
     end
 
+    # Used for rft.date in the ILLiad get-this request form.
+    # @return [String]
     def date
       d = fetch_marc("260", "c")
       d = fetch_marc("264", "c") if d == ""
       d
     end
 
+    # Used for rft.pub in the ILLiad get-this request form
+    # @return [String]
     def pub
-      fetch_marc("260", "b")
+      p = fetch_marc("260", "b")
+      p = fetch_marc("264", "b") if p == ""
+      p
     end
 
     def place

--- a/local-gems/spectrum-json/lib/spectrum/bib_record.rb
+++ b/local-gems/spectrum-json/lib/spectrum/bib_record.rb
@@ -90,7 +90,9 @@ module Spectrum
     end
 
     def date
-      fetch_marc("260", "c")
+      d = fetch_marc("260", "c")
+      d = fetch_marc("264", "c") if d == ""
+      d
     end
 
     def pub
@@ -246,7 +248,7 @@ module Spectrum
       # people out of the proxy server.  So add a campus-agnostic proxy prefix.
       def link
         return @holding["link"] if @holding["link"]&.include?("alma.exlibrisgroup")
-        "https://apps.lib.umich.edu/proxy-login/?qurl=#{URI::encode_www_form_component(@holding["link"])}"
+        "https://apps.lib.umich.edu/proxy-login/?qurl=#{URI.encode_www_form_component(@holding["link"])}"
       end
     end
 

--- a/local-gems/spectrum-json/lib/spectrum/decorators/physical_item_decorator.rb
+++ b/local-gems/spectrum-json/lib/spectrum/decorators/physical_item_decorator.rb
@@ -71,6 +71,13 @@ module Spectrum::Decorators
       @work_order_option = work_order_option
     end
 
+    # mrio: 2024-06 Document Delivery wants alma_location to return the
+    # location code and the library display name.
+    # Example: GRAD Hatcher Graduate
+    def location_for_illiad
+      [@item.permanent_location, @item.library_display_name].compact.join(" ")
+    end
+
     # mrio: 2022-09 per request from Dave in CVGA that items in SHAP Game
     #      are only "Find it in the Library"; Media Fullfillment Unit is
     #      pretty inconsistent so we can't use that

--- a/local-gems/spectrum-json/lib/spectrum/entities/get_this_option.rb
+++ b/local-gems/spectrum-json/lib/spectrum/entities/get_this_option.rb
@@ -207,7 +207,7 @@ class Spectrum::Entities::GetThisOption
            "name" => "rft.au",
            "value" => @item.author},
           {"type" => "hidden",
-           "name" => "date",
+           "name" => "rft.date",
            "value" => @item.date},
           {"type" => "hidden",
            "name" => "rft.pub",

--- a/local-gems/spectrum-json/lib/spectrum/entities/get_this_option.rb
+++ b/local-gems/spectrum-json/lib/spectrum/entities/get_this_option.rb
@@ -220,17 +220,13 @@ class Spectrum::Entities::GetThisOption
            "value" => @item.callnumber},
           {"type" => "hidden",
            "name" => "rft.edition",
-           "value" => @item.edition}, # is this in item
+           "value" => @item.edition},
           {"type" => "hidden",
            "name" => "rft.issue",
            "value" => ""},
           {"type" => "hidden",
-           "name" => "aleph_location",
-           "value" => @item.library_display_name},
-          {"type" => "hidden",
-           "name" => "aleph_item_status",
-           "value" => ""},
-          # this only exists for Spectrum::EmptyItemHolding
+           "name" => "alma_location",
+           "value" => @item.location_for_illiad},
           {
             "type" => "hidden",
             "name" => "CitedTitle",

--- a/spec/fixtures/get_this/illiad_request.json
+++ b/spec/fixtures/get_this/illiad_request.json
@@ -37,7 +37,7 @@
             "value": "AUTHOR"
         },
         {
-            "name": "date",
+            "name": "rft.date",
             "type": "hidden",
             "value": "DATE"
         },

--- a/spec/fixtures/get_this/illiad_request.json
+++ b/spec/fixtures/get_this/illiad_request.json
@@ -67,14 +67,9 @@
             "value": ""
         },
         {
-            "name": "aleph_location",
+            "name": "alma_location",
             "type": "hidden",
             "value": "LOCATION"
-        },
-        {
-            "name": "aleph_item_status",
-            "type": "hidden",
-            "value": ""
         },
         {
             "name": "CitedTitle",

--- a/spec/fixtures/solr_bib_on_order_with_264.json
+++ b/spec/fixtures/solr_bib_on_order_with_264.json
@@ -1,0 +1,143 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 0,
+    "params": {
+      "q": "id:99188004813606381"
+    }
+  },
+  "response": {
+    "numFound": 1,
+    "start": 0,
+    "docs": [
+      {
+        "indexing_date": 20240620,
+        "id": "99188004813606381",
+        "id_int": 99188004813606380,
+        "oclc": [
+          "1439828923"
+        ],
+        "record_source": "alma",
+        "fullrecord": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><collection><record><leader>00733nam a22002177i 4500</leader><controlfield tag=\"005\">20240619112532.0</controlfield><controlfield tag=\"008\">240508t20242024fr            000 0 fre d</controlfield><controlfield tag=\"001\">99188004813606381</controlfield><datafield tag=\"020\" ind1=\" \" ind2=\" \"><subfield code=\"a\">9782406166733</subfield><subfield code=\"q\">(paperback)</subfield></datafield><datafield tag=\"020\" ind1=\" \" ind2=\" \"><subfield code=\"a\">2406166732</subfield></datafield><datafield tag=\"035\" ind1=\" \" ind2=\" \"><subfield code=\"a\">(OCoLC)1439828923</subfield></datafield><datafield tag=\"035\" ind1=\" \" ind2=\" \"><subfield code=\"a\">(OCoLC)on1439828923</subfield></datafield><datafield tag=\"040\" ind1=\" \" ind2=\" \"><subfield code=\"a\">AUXAM</subfield><subfield code=\"b\">eng</subfield><subfield code=\"e\">rda</subfield><subfield code=\"c\">AUXAM</subfield></datafield><datafield tag=\"082\" ind1=\"1\" ind2=\"4\"><subfield code=\"a\">809</subfield></datafield><datafield tag=\"100\" ind1=\"1\" ind2=\" \"><subfield code=\"a\">Kovacshazy, Cécile,</subfield><subfield code=\"e\">author.</subfield><subfield code=\"0\">http://id.loc.gov/authorities/names/nb2010012539</subfield><subfield code=\"0\">http://viaf.org/viaf/232823993</subfield></datafield><datafield tag=\"245\" ind1=\"1\" ind2=\"0\"><subfield code=\"a\">Serpillières, mansardes et dominations :</subfield><subfield code=\"b\">femmes domestiques dans la littérature européenne /</subfield><subfield code=\"c\">Cécile Kovacshazy.</subfield></datafield><datafield tag=\"264\" ind1=\" \" ind2=\"1\"><subfield code=\"a\">Paris :</subfield><subfield code=\"b\">Classiques Garnier,</subfield><subfield code=\"c\">2024.</subfield></datafield><datafield tag=\"264\" ind1=\" \" ind2=\"4\"><subfield code=\"c\">©2024</subfield></datafield><datafield tag=\"300\" ind1=\" \" ind2=\" \"><subfield code=\"a\">344 pages ;</subfield><subfield code=\"c\">22 cm.</subfield></datafield><datafield tag=\"490\" ind1=\"0\" ind2=\" \"><subfield code=\"a\">Perspectives comparatistes,</subfield><subfield code=\"x\">2103-480X</subfield></datafield><datafield tag=\"938\" ind1=\" \" ind2=\" \"><subfield code=\"a\">AMALIVRE</subfield><subfield code=\"b\">AUXA</subfield><subfield code=\"n\">AAL08376666-0001</subfield></datafield><datafield tag=\"BIB\" ind1=\" \" ind2=\" \"><subfield code=\"u\">2024-06-19 11:25:32 US/Eastern</subfield><subfield code=\"c\">2024-06-19 11:25:31 US/Eastern</subfield><subfield code=\"s\">false</subfield></datafield><datafield tag=\"852\" ind1=\"0\" ind2=\" \"><subfield code=\"b\">HATCH</subfield><subfield code=\"a\">MiU</subfield><subfield code=\"c\">GRAD</subfield><subfield code=\"h\"></subfield><subfield code=\"8\">221303350300006381</subfield></datafield><datafield tag=\"974\" ind1=\" \" ind2=\" \"><subfield code=\"8\">221303350300006381</subfield><subfield code=\"f\">0</subfield><subfield code=\"t\">ACQ</subfield><subfield code=\"c\">GRAD</subfield><subfield code=\"m\">BOOK</subfield><subfield code=\"e\">GRAD</subfield><subfield code=\"7\">231303350290006381</subfield><subfield code=\"d\">HATCH</subfield><subfield code=\"b\">HATCH</subfield></datafield></record></collection>",
+        "format": [
+          "Book"
+        ],
+        "isbn": [
+          "9782406166733",
+          "2406166732"
+        ],
+        "isn_related": [
+          "2103-480X"
+        ],
+        "mainauthor": [
+          "Kovacshazy, Cécile,"
+        ],
+        "mainauthor_role": [
+          "author"
+        ],
+        "author": [
+          "Kovacshazy, Cécile,"
+        ],
+        "authorStr": [
+          "Kovacshazy, Cécile,"
+        ],
+        "author_top": [
+          "Kovacshazy, Cécile, author. http://id.loc.gov/authorities/names/nb2010012539 http://viaf.org/viaf/232823993",
+          "Cécile Kovacshazy."
+        ],
+        "author_browse_terms": [
+          "Kovacshazy, Cécile,"
+        ],
+        "author_browse_search": [
+          "kovacshazy cecile"
+        ],
+        "author_authoritative_browse": [
+          "Kovacshazy, Cécile,"
+        ],
+        "author_authoritative_search": [
+          "kovacshazy cecile"
+        ],
+        "main_author_display": [
+          "Kovacshazy, Cécile, author."
+        ],
+        "main_author": [
+          "Kovacshazy, Cécile,"
+        ],
+        "title": [
+          "Serpillières, mansardes et dominations : femmes domestiques dans la littérature européenne /"
+        ],
+        "title_a": [
+          "Serpillières, mansardes et dominations :"
+        ],
+        "title_ab": [
+          "Serpillières, mansardes et dominations : femmes domestiques dans la littérature européenne /"
+        ],
+        "title_c": [
+          "Cécile Kovacshazy."
+        ],
+        "title_common": [
+          "Serpillières, mansardes et dominations : femmes domestiques dans la littérature européenne /"
+        ],
+        "title_equiv": [
+          "Serpillières, mansardes et dominations : femmes domestiques dans la littérature européenne /"
+        ],
+        "title_top": [
+          "Serpillières, mansardes et dominations : femmes domestiques dans la littérature européenne /"
+        ],
+        "title_rest": [
+          "Perspectives comparatistes, 2103-480X"
+        ],
+        "series2": [
+          "Perspectives comparatistes, 2103-480X"
+        ],
+        "countryOfPubStr": [
+          "France"
+        ],
+        "place_of_publication": [
+          "France"
+        ],
+        "publishDate": [
+          "2024"
+        ],
+        "publishDateRange": [
+          "2024",
+          "2020-2029"
+        ],
+        "display_date": "2024",
+        "publisher": [
+          "Paris : Classiques Garnier, 2024."
+        ],
+        "publisher_display": [
+          "Paris : Classiques Garnier, 2024."
+        ],
+        "language": [
+          "French"
+        ],
+        "language008": "fre",
+        "title_display": [
+          "Serpillières, mansardes et dominations : femmes domestiques dans la littérature européenne / Cécile Kovacshazy."
+        ],
+        "cat_date": 20240508,
+        "building": [
+          "Hatcher Graduate"
+        ],
+        "ht_searchonly": false,
+        "ht_searchonly_intl": false,
+        "hol": "[{\"hol_mmsid\":\"221303350300006381\",\"callnumber\":\"\",\"library\":\"HATCH\",\"location\":\"GRAD\",\"info_link\":\"https://lib.umich.edu/locations-and-hours/hatcher-library\",\"display_name\":\"Hatcher Graduate\",\"floor_location\":\"\",\"public_note\":null,\"items\":[{\"barcode\":null,\"library\":\"HATCH\",\"location\":\"GRAD\",\"info_link\":\"https://lib.umich.edu/locations-and-hours/hatcher-library\",\"display_name\":\"Hatcher Graduate\",\"fulfillment_unit\":\"General\",\"location_type\":\"OPEN\",\"can_reserve\":false,\"permanent_library\":\"HATCH\",\"permanent_location\":\"GRAD\",\"temp_location\":false,\"callnumber\":null,\"public_note\":null,\"process_type\":\"ACQ\",\"item_policy\":null,\"description\":null,\"inventory_number\":null,\"item_id\":\"231303350290006381\",\"material_type\":\"BOOK\",\"record_has_finding_aid\":false}],\"summary_holdings\":null,\"record_has_finding_aid\":false}]",
+        "location": [
+          "HATCH",
+          "HATCH GRAD",
+          "MIU"
+        ],
+        "institution": [
+          "UM Ann Arbor Libraries",
+          "University Library"
+        ],
+        "callnosort": "\u001f}",
+        "callnumber_sort": "\u001f}",
+        "date_of_index": "2024-06-20T00:00:00Z",
+        "_version_": 1802365487708897300
+      }
+    ]
+  }
+}

--- a/spec/spectrum/bib_record_spec.rb
+++ b/spec/spectrum/bib_record_spec.rb
@@ -253,8 +253,12 @@ describe Spectrum::BibRecord do
   end
 
   context "#pub" do
-    it "returns a string" do
+    it "returns a string from 260" do
       expect(subject.pub).to eq("Jossey-Bass Publishers")
+    end
+    it "returns a string from 264" do
+      @solr_bib_alma = File.read("spec/fixtures/solr_bib_on_order_with_264.json")
+      expect(subject.pub).to eq("Classiques Garnier")
     end
   end
 

--- a/spec/spectrum/bib_record_spec.rb
+++ b/spec/spectrum/bib_record_spec.rb
@@ -115,7 +115,7 @@ describe Spectrum::BibRecord do
         expect(subject.physical_holdings?).to eq(true)
       end
       it "returns false for only holdings with library ELEC" do
-        @solr_bib_alma = @solr_bib_alma.gsub(/HATCH/, "ELEC")
+        @solr_bib_alma = @solr_bib_alma.gsub("HATCH", "ELEC")
         expect(subject.physical_holdings?).to eq(false)
       end
     end
@@ -124,7 +124,7 @@ describe Spectrum::BibRecord do
         expect(subject.hathi_holding.class.name.to_s).to eq("Spectrum::BibRecord::HathiHolding")
       end
       it "returns nil for no Hathi Item" do
-        @solr_bib_alma = @solr_bib_alma.gsub(/HathiTrust/, "SomeOtherTrust")
+        @solr_bib_alma = @solr_bib_alma.gsub("HathiTrust", "SomeOtherTrust")
         expect(subject.hathi_holding).to be_nil
       end
     end
@@ -189,11 +189,11 @@ describe Spectrum::BibRecord do
           expect(subject.finding_aid).to be_nil
         end
         it "returns nil when no finding aid" do
-          @solr_elec = @solr_elec.gsub(/finding_aid\\":false,/, "")
+          @solr_elec = @solr_elec.gsub('finding_aid\\":false,', "")
           expect(subject.finding_aid).to be_nil
         end
         it "returns holding when there is a finding_aid" do
-          @solr_elec = @solr_elec.gsub(/finding_aid\\":false/, "finding_aid\\\":true")
+          @solr_elec = @solr_elec.gsub('finding_aid\\":false', "finding_aid\\\":true")
           expect(subject.finding_aid.class.name).to include("FindingAid")
         end
       end
@@ -243,8 +243,12 @@ describe Spectrum::BibRecord do
   end
 
   context "#date" do
-    it "returns a string" do
+    it "returns a string from 260" do
       expect(subject.date).to eq("1990")
+    end
+    it "returns a string from 264" do
+      @solr_bib_alma = File.read("spec/fixtures/solr_bib_on_order_with_264.json")
+      expect(subject.date).to eq("2024")
     end
   end
 
@@ -327,7 +331,7 @@ describe Spectrum::BibRecord::ElectronicHolding do
 
     context "When the holding has an non-Alma link" do
       let(:url) { "https://www.lib.umich.edu" }
-      let(:proxied_url) { "https://apps.lib.umich.edu/proxy-login/?qurl=#{URI::encode_www_form_component(url)}" }
+      let(:proxied_url) { "https://apps.lib.umich.edu/proxy-login/?qurl=#{URI.encode_www_form_component(url)}" }
 
       it "Returns the proxied link" do
         expect(subject.link).to eq(proxied_url)

--- a/spec/spectrum/decorators/physical_item_decorator_spec.rb
+++ b/spec/spectrum/decorators/physical_item_decorator_spec.rb
@@ -17,6 +17,13 @@ describe Spectrum::Decorators::PhysicalItemDecorator do
     item = Spectrum::Entities::AlmaItem.new(**@input)
     described_class.new(item, [], @get_this_work_order_double)
   end
+  context "location_for_illiad" do
+    it "returns expected form of illiad location" do
+      allow(@input[:solr_item]).to receive(:permanent_location).and_return("GRAD")
+      allow(@input[:holding]).to receive(:display_name).and_return("Hatcher Graduate")
+      expect(subject.location_for_illiad).to eq("GRAD Hatcher Graduate")
+    end
+  end
   context "work order methods" do
     # mrio: both of these would be booleans, but having them return strings shows
     # that the correct path through the code is being used.

--- a/spec/spectrum/entities/get_this_option_spec.rb
+++ b/spec/spectrum/entities/get_this_option_spec.rb
@@ -78,7 +78,7 @@ describe Spectrum::Entities::GetThisOption do
       allow(@item).to receive(:place).and_return("PLACE")
       allow(@item).to receive(:callnumber).and_return("CALLNUMBER")
       allow(@item).to receive(:edition).and_return("EDITION")
-      allow(@item).to receive(:library_display_name).and_return("LOCATION")
+      allow(@item).to receive(:location_for_illiad).and_return("LOCATION")
       allow(@item).to receive(:barcode).and_return("BARCODE")
       allow(@item).to receive(:oclc).and_return("OCLC")
       allow(@item).to receive(:cited_title).and_return("CITED_TITLE")


### PR DESCRIPTION
Addresses 
* [LIBSEARCH-961](https://mlit.atlassian.net/browse/LIBSEARCH-961)
* [LIBSEARCH-973](https://mlit.atlassian.net/browse/LIBSEARCH-973)

## 961
In the ILLiad get-this request form we are changing `date` to `rft.date`. For the date we are using the value from 264 c if 260 c is empty. For `rft.pub` we are using 264 b if 260 b is empty. 

## 973
In the ILLiad get-this request form we are changing:
* `aleph_location` to `alma_location`

We are removing `aleph_item_status` because it is not used. 

`alma_location` will have the Location code as well as the display name of the library. Example: GRAD Hatcher Graduate.
