### PR TITLE
Bugfix for article full text availability

### DIFF
--- a/local-gems/spectrum-config/lib/spectrum/search_engines/primo/doc.rb
+++ b/local-gems/spectrum-config/lib/spectrum/search_engines/primo/doc.rb
@@ -36,9 +36,7 @@ module Spectrum
         end
 
         def fulltext?
-          @fulltext ||= @delivery['availability'].any? do |availability|
-            availability.include?('fulltext')
-          end
+          @fulltext ||= @delivery['availability'].include?('fulltext')
         end
 
         def link_to_resource?


### PR DESCRIPTION
Metadata for records without fulltext is 'no_fulltext' which had a false positive with the previous code.