### PR TITLE
Adding prometheus metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,10 @@ gem "json"
 gem "httpclient"
 gem "nokogiri"
 
-# HTML replacement language
+group :yabeda do
+  gem "yabeda-puma-plugin"
+  gem "yabeda-prometheus"
+end
 
 # "Rack middleware which cleans up invalid UTF8 characters"
 # gem 'rack-utf8_sanitizer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     aes_key_wrap (1.1.0)
+    anyway_config (2.6.4)
+      ruby-next-core (~> 1.0)
     ast (2.4.2)
     attr_required (1.0.2)
     base64 (0.2.0)
@@ -110,6 +112,7 @@ GEM
     down (5.4.2)
       addressable (~> 2.8)
     drb (2.2.1)
+    dry-initializer (3.1.1)
     email_validator (2.2.4)
       activemodel
     erb (4.0.4)
@@ -212,6 +215,8 @@ GEM
       ast (~> 2.4.1)
       racc
     parslet (2.0.0)
+    prometheus-client (4.2.3)
+      base64
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -279,6 +284,7 @@ GEM
     rubocop-performance (1.21.1)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-next-core (1.0.3)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     scrub_rb (1.0.1)
@@ -341,6 +347,18 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    yabeda (0.13.1)
+      anyway_config (>= 1.0, < 3)
+      concurrent-ruby
+      dry-initializer
+    yabeda-prometheus (0.9.1)
+      prometheus-client (>= 3.0, < 5.0)
+      rack
+      yabeda (~> 0.10)
+    yabeda-puma-plugin (0.7.1)
+      json
+      puma
+      yabeda (~> 0.5)
 
 PLATFORMS
   ruby
@@ -380,6 +398,8 @@ DEPENDENCIES
   standard
   twilio-ruby
   webmock
+  yabeda-prometheus
+  yabeda-puma-plugin
 
 BUNDLED WITH
    2.5.16

--- a/config.ru
+++ b/config.ru
@@ -5,8 +5,27 @@ end
 
 ENV['APP_ENV'] ||= ENV['RAILS_ENV']
 
+# If yabeda will try to use Railties if Rails is defined.
+# rails-html-sanitizer defines Rails, and is used in spectrum.
+# Thus Yabeda has to be loaded before everything else.
 require "bundler"
+Bundler.require :yabeda
 Bundler.require
+
+require "prometheus/middleware/collector"
+
+if (monitoring_dir = ENV["PROMETHEUS_MONITORING_DIR"])
+  FileUtils.mkdir_p(monitoring_dir)
+  Dir[File.join(monitoring_dir, "*.bin")].each do |file_path|
+    File.unlink(file_path)
+  end
+  Prometheus::Client.config.data_store =
+    Prometheus::Client::DataStores::DirectFileStore.new( dir: monitoring_dir )
+end
+
+Yabeda.configure!
+use Prometheus::Middleware::Collector
+
 Spectrum::Json.configure(__dir__, ENV["RAILS_RELATIVE_URL_ROOT"])
 
 use Rack::ReverseProxy do

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -41,4 +41,22 @@ worker_timeout 120
   #ActiveRecord::Base.connection_pool.disconnect!
 #end
 
-activate_control_app ENV['PUMA_CONTROL_APP'], {no_token: true} if ENV['PUMA_CONTROL_APP']
+if ENV["PUMA_CONTROL_APP"]
+  activate_control_app ENV["PUMA_CONTROL_APP"], {no_token: true}
+
+  if ENV["PROMETHEUS_EXPORTER_URL"]
+    plugin :yabeda
+    plugin :yabeda_prometheus
+    prometheus_exporter_url ENV["PROMETHEUS_EXPORTER_URL"]
+
+    if (monitoring_dir = ENV["PROMETHEUS_MONITORING_DIR"])
+      before_fork do
+        Prometheus::Client.config.data_store =
+          Prometheus::Client::DataStores::DirectFileStore.new( dir: monitoring_dir )
+      end
+    end
+
+
+
+  end
+end


### PR DESCRIPTION
This may not be the final configuration.

In particular, I don't fully understand why Prometheus::Client.config.data_store has to be set in both config.ru and config/puma.rb.  Some metrics appear to be absent if I don't. That said.  metrics are being served in my docker-compose environment, so I think this is a good starting point.