### PR TITLE
[LIBSEARCH-141] Update "Main Author" label to be "Author/Creator"

### DIFF
--- a/config/fields.yml
+++ b/config/fields.yml
@@ -2234,7 +2234,7 @@
 
 - id: main_author
   metadata:
-    name: Main Author
+    name: Author/Creator
   type: marcxml
   field: fullrecord
   marc:


### PR DESCRIPTION
From [LIBSEARCH-141](https://mlit.atlassian.net/browse/LIBSEARCH-141):
> Change the label in brief, medium, and full view catalog records for field id "main_author" from "Main Author" to "Author/Creator".