### PR TITLE
[LIBSEARCH-1042] Update Articles & Catalog medium view

### DIFF
--- a/config/fields.yml
+++ b/config/fields.yml
@@ -866,6 +866,9 @@
   filters:
     - id: sanitize
       method: sanitize
+  metadata_component:
+    medium:
+      type: plain
 
 - id: subject
   metadata:
@@ -1552,6 +1555,10 @@
     short_desc: Subject
   searchable: true
   metadata_component:
+    medium:
+      type: search1
+      scope: subject
+      variant: filtered
     full:
       type: search1
       scope: subject
@@ -2529,6 +2536,8 @@
         sub: '[abc3]'
         ind1: '[^4]'
   metadata_component:
+    medium:
+      type: plain
     full:
       type: plain
 

--- a/config/fields.yml
+++ b/config/fields.yml
@@ -3571,6 +3571,10 @@
   metadata:
     name: Subjects (LCSH)
   metadata_component:
+    medium:
+      type: quoted_search3
+      variant: fielded
+      scope: subject
     full:
       type: search_browse2
       search_variant: fielded


### PR DESCRIPTION
# Overview
From [LIBSEARCH-1042](https://mlit.atlassian.net/browse/LIBSEARCH-1042):
> Catalog, medium view:
> * Add Summary (after 230 characters, truncate and replace positions 231+ with an ellipsis)
> * Add Subjects (LCSH), limited to first 3 results with a “Show all ##” button to display all
>
> Articles, medium view:
> * Add Abstract (after 230 characters, truncate and replace positions 231+ with an ellipsis)
> * Add Subjects, limited to first 3 results with a “Show all ##” button to display all 

This pull request displays the necessary data for the views.

`quoted_search3` was chosen for `lc_subject_display` so the `| Browse in subject list` link would not appear, as it does not appear for displayed authors in `medium` view.

The [pull request](https://github.com/mlibrary/search/pull/507) for truncating the new data.
