### PR TITLE
LIBSEARCH-1036 Putting article page ranges into the RIS SP field

### DIFF
--- a/config/fields.yml
+++ b/config/fields.yml
@@ -4264,6 +4264,8 @@
     id: page
   z3988:
     id: rft.pages
+  ris:
+    - SP
   metadata:
     name: Pages
   metadata_component:


### PR DESCRIPTION
Primo doesn't seem to give a separate "start page" and "end page". There is a pages field, though, and we're using that in the UI.

This puts the pages into the SP field for RIS exports.