### PR TITLE
Addressing inconsistencies in slug generation.

### DIFF
--- a/local-gems/spectrum-config/lib/spectrum/config/highly_recommended.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/highly_recommended.rb
@@ -13,7 +13,7 @@ module Spectrum
 
       def map(value)
         return nil unless value.respond_to?(:downcase)
-        "#{prefix}#{value.downcase.gsub(/[^a-z&']/, '_').gsub(/_+/, '_').sub(/_+$/, '')}#{suffix} asc"
+        "#{prefix}#{value.downcase.gsub(/[^a-z&'.]/, '_').gsub(/_+/, '_').sub(/_+$/, '')}#{suffix} asc"
       end
 
       def get_sorts(sort, facets)


### PR DESCRIPTION
We convert AD categories to slugs or machine names. It's not being done consistently everwhere.

This makes the machine names match what DDM is producing.