### PR TITLE
Adding Rack::Attack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "ostruct"
 gem "logger"
 
 gem "rack-reverse-proxy", require: "rack/reverse_proxy"
+gem "rack-attack"
 
 # Allow dotenv configuration
 gem "dotenv", require: "dotenv/load"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.9)
+    rack-attack (6.7.0)
+      rack (>= 1.0, < 4)
     rack-oauth2 (2.2.1)
       activesupport
       attr_required
@@ -385,6 +387,7 @@ DEPENDENCIES
   pry
   pry-byebug
   puma
+  rack-attack
   rack-reverse-proxy
   rack-test
   rack-utf8_sanitizer!

--- a/config.ru
+++ b/config.ru
@@ -17,4 +17,9 @@ use Rack::ReverseProxy do
   reverse_proxy %r{^/catalog/browse/(.*)$}, "https://#{ENV["BROWSE_HOST"]}/$1"
 end
 
+use Rack::Attack
+ENV.fetch("RACK_IP_BLOCKLIST", "").split(/\s/).each do |ip|
+  Rack::Attack.blocklist_ip(ip)
+end
+
 run Spectrum::Json::App


### PR DESCRIPTION
Leveraging an optional environement variable, RACK_BLOCKLIST_IP to declare blocked IP addresses.  It splits on \s, so fill the variable with space-separated IP addresses.

This is intended for short-term blocking in response to the Christmas Eve Primo/Alma API Limit threshold and misbehaving Search clients.

Long-term blocking should be handled by the load balancer.