### PR TITLE
Add metrics using instrumentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,10 +52,10 @@ gem "json"
 gem "httpclient"
 gem "nokogiri"
 
-group :yabeda do
+group :metrics do
   gem "yabeda-puma-plugin"
   gem "yabeda-prometheus"
-  gem "prometheus-client", require: "prometheus/middleware/collector"
+  gem "prometheus-client", require: File.expand_path(File.join(["lib", "metrics"]), __dir__)
 end
 
 # "Rack middleware which cleans up invalid UTF8 characters"

--- a/README.notifications.md
+++ b/README.notifications.md
@@ -1,0 +1,18 @@
+# ActiveSupport::Notifications
+
+This commit is adding ActiveSupport::Notifications instrumentation.  I am describing that in the following table.
+
+
+| Event                                                    | Purpose                                             | Payload                         |
+|----------------------------------------------------------|-----------------------------------------------------|---------------------------------|
+| `primo_search.spectrum_search_engine_primo`              | Timing for primo API requests                       | `:source_id`, `:params`, `:url` |
+| `libkey_search.spectrum_search_engine_primo`             | Timing for libkey API requests                      | `:source_id`, `:params`, `:url` |
+| `primo_results.spectrum_search_engine_primo`             | Data about primo search results                     | `:results`                      |
+| `solr_search.spectrum_search_engine_solr`                | Timing for solr API requests                        | `:source_id`, `:params`         |
+| `solr_results.spectrum_search_engine_solr`               | Data about solr search results a                    | `:results`                      |
+| `search_results_holdings_retrieval.spectrum_json_search` | Timing for retrieving holdings for search results   | `:full_response`                |
+| `single_record_holdings_retrieval.spectrum_json_search`  | Timing for retireiving holdings for a single record | `:spectrum_response`            |
+| `email.spectrum_json_act`                                | Timing for Email actions, retrieving records        | `:data`, `:username`, `:role`   |
+| `file.spectrum_json_act`                                 | Timing for RIS actions, retrieving records          | `:data`, `:username`, `:role`   |
+| `text.spectrum_json_act`                                 | Timing for Text actions, retireiving records        | `:data`, `:username`, `:role`   |
+| `track.rack_attack`                                      | Data about http requests with cookies               | `:request`                      |

--- a/config.ru
+++ b/config.ru
@@ -18,14 +18,19 @@ use Rack::ReverseProxy do
 end
 
 use Rack::Attack
+
+Rack::Attack.track("has_cookie") do |req|
+  req.env.has_key?("HTTP_COOKIE")
+end
+
 ENV.fetch("RACK_IP_BLOCKLIST", "").split(/\s/).each do |ip|
   Rack::Attack.blocklist_ip(ip)
 end
 
 if ENV.fetch("RACK_THROTTLE", false)
   Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
-  Rack::Attack.throttle('limit requests for /spectrum/.*/record', limit: 3, period: 60) do |req|
-    if req.path.match(%r{/spectrum/.*/record/})
+  Rack::Attack.throttle("limit requests for /spectrum/.*/record", limit: 3, period: 60) do |req|
+    if %r{/spectrum/.*/record/}.match?(req.path)
       req.ip
     end
   end

--- a/config.ru
+++ b/config.ru
@@ -5,9 +5,7 @@ end
 
 ENV["APP_ENV"] ||= ENV["RAILS_ENV"]
 
-if ENV["PROMETHEUS_EXPORTER_URL"]
-  use Prometheus::Middleware::Collector
-end
+use Metrics::Middleware
 
 Bundler.require
 Spectrum::Json.configure(__dir__, ENV["RAILS_RELATIVE_URL_ROOT"])
@@ -19,7 +17,7 @@ end
 
 use Rack::Attack
 
-Rack::Attack.track("has_cookie") do |req|
+Rack::Attack.track("haz_cookie") do |req|
   req.env.has_key?("HTTP_COOKIE")
 end
 

--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -1,0 +1,36 @@
+---
+data_store:
+  class: "Prometheus::Client::DataStores::DirectFileStore"
+  dir: <%= ENV.fetch("PROMETHEUS_MONITORING_DIR", "/tmp/search/metrics") %>
+subscriptions: "config/subscriptions.rb"
+puma:
+  control_app_url: <%= ENV.fetch("PUMA_CONTROL_APP", "unix:///tmp/search.sock") %>
+  prometheus_exporter_url: <%= ENV.fetch("PROMETHEUS_EXPORTER_URL", "tcp://0.0.0.0:9439/metrics") %>
+metrics:
+- type: counter
+  name: http_server_requests_total
+  docstring: "The total number of HTTP requests handled by the Rack application."
+  labels:
+  - code
+  - method
+  - path
+- type: histogram
+  name: http_server_request_duration_seconds
+  docstring: "The HTTP response duration of the Rack application."
+  labels:
+  - method
+  - path
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 20, 30]
+- type: histogram
+  name: api_response_duration_seconds
+  docstring: "The API response duration for requests made by Spectrum."
+  labels:
+  - source
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 20, 30]
+- type: histogram
+  name: cookie_size_bytes
+  docstring: "The http request cookie sizes in bytes"
+  buckets: [500, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 7500, 8000]
+- type: counter
+  name: cookie_purges
+  docstring: "The total number of cookie purges initiated by spectrum"

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -43,76 +43,7 @@ worker_timeout 120
 #   ActiveRecord::Base.connection_pool.disconnect!
 # end
 
-if ENV["PUMA_CONTROL_APP"]
-  activate_control_app ENV["PUMA_CONTROL_APP"], {no_token: true}
+Bundler.require :metrics
+Metrics.load_config
+Metrics.configure_puma(self)
 
-  if ENV["PROMETHEUS_EXPORTER_URL"]
-    Bundler.require :yabeda
-
-    plugin :yabeda
-    plugin :yabeda_prometheus
-    prometheus_exporter_url ENV["PROMETHEUS_EXPORTER_URL"]
-
-    on_worker_boot do
-      # Prometheus::Middleware::Collector.new has side effects that registers
-      # metrics.  If they are already loaded it raises an exception.
-      if Prometheus::Client.registry.exist?(:http_server_requests_total)
-        Prometheus::Client.registry.unregister(:http_server_requests_total)
-        Prometheus::Client.registry.unregister(:http_server_request_duration_seconds)
-        Prometheus::Client.registry.unregister(:http_server_exceptions_total)
-      end
-
-      uri = URI(ENV["PROMETHEUS_EXPORTER_URL"])
-      ObjectSpace.each_object(TCPServer).each do |server|
-        next if server.closed?
-        family, port, host, _ = server.addr
-        if family == "AF_INET" && port == uri.port && host == uri.host
-          server.close
-        end
-      end
-    end
-
-    if (monitoring_dir = ENV["PROMETHEUS_MONITORING_DIR"])
-      on_prometheus_exporter_boot do
-        # http_server_exceptions_total was generating invalid metrics for us
-        if Prometheus::Client.registry.exist?(:http_server_exceptions_total)
-          Prometheus::Client.registry.unregister(:http_server_exceptions_total)
-        end
-        # In clustered mode, the worker processes get these registered, but the coordinating process does not.
-        # Ending up in these stats being collected, but not reported.
-        unless Prometheus::Client.registry.exist?(:http_server_requests_total)
-          # These are copied from Prometheus::Middleware::Collector#init_request_metrics
-          # and  Prometheus::Middleware::Collector#init_exception_metrics
-          Prometheus::Client.registry.counter(
-            :http_server_requests_total,
-            docstring: "The total number of HTTP requests handled by the Rack application.",
-            labels: %i[code method path]
-          )
-          Prometheus::Client.registry.histogram(
-            :http_server_request_duration_seconds,
-            docstring: "The HTTP response duration of the Rack application.",
-            labels: %i[method path]
-          )
-          # http_server_exceptions_total was generating invalid metrics for us.
-          # Prometheus::Client.registry.histogram(
-          #   :http_server_exceptions_total,
-          #   docstring: "The total number of exceptions raised by the Rack application.",
-          #   labels: [:exception]
-          # )
-
-          Dir[File.join(monitoring_dir, "*.bin")].each do |file_path|
-            File.unlink(file_path)
-          end
-
-          Yabeda.configure!
-        end
-      end
-
-      before_fork do
-        Prometheus::Client.config.data_store =
-          Prometheus::Client::DataStores::DirectFileStore.new(dir: monitoring_dir)
-      end
-    end
-
-  end
-end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,5 +1,5 @@
 require "dotenv"
-Dotenv.load(File.expand_path("../../.env", __FILE__))
+Dotenv.load(File.expand_path(File.join("..", ".env"), __dir__))
 
 ENV["RAILS_RELATIVE_URL_ROOT"] ||= "http://localhost:3000"
 

--- a/config/subscriptions.rb
+++ b/config/subscriptions.rb
@@ -1,0 +1,77 @@
+ActiveSupport::Notifications.subscribe("track.rack_attack") do |event|
+  next unless event.payload[:request].env["rack.attack.matched"] == "haz_cookie"
+  Metrics(:cookie_size_bytes) do |metric|
+    metric.observe(event.payload[:request].env["HTTP_COOKIE"].bytesize)
+  end
+end
+
+ActiveSupport::Notifications.subscribe("cookie_purge.spectrum_json") do |event|
+  Metrics(:cookie_purge) do |metric|
+    metric.increment
+  end
+end
+
+ActiveSupport::Notifications.subscribe("primo_search.spectrum_search_engine_primo") do |event|
+  Metrics(:api_response_duration_seconds) do |metric|
+    metric.observe(event.duration / 1000, labels: {source: event.payload[:source_id]})
+  end
+end
+
+ActiveSupport::Notifications.subscribe("libkey_search.spectrum_search_engine_primo") do |event|
+  Metrics(:api_response_duration_seconds) do |metric|
+    metric.observe(event.duration / 1000, labels: {source: event.payload[:source_id]})
+  end
+end
+
+ActiveSupport::Notifications.subscribe("solr_search.spectrum_search_engine_solr") do |event|
+  Metrics(:api_response_duration_seconds) do |metric|
+    metric.observe(event.duration / 1000, labels: {source: event.payload[:source_id]})
+  end
+end
+
+ActiveSupport::Notifications.subscribe("search_results_holdings_retrieval.spectrum_json_search") do |event|
+  Metrics(:api_response_duration_seconds) do |metric|
+    metric.observe(event.duration / 1000, labels: {source: "alma-search-holdings"})
+  end
+end
+
+ActiveSupport::Notifications.subscribe("single_record_holdings_retrieval.spectrum_json_search") do |event|
+  Metrics(:api_response_duration_seconds) do |metric|
+    metric.observe(event.duration / 1000, labels: {source: "alma-single-holdings"})
+  end
+end
+
+ActiveSupport::Notifications.subscribe("email.spectrum_json_act") do |event|
+  Metrics(:api_response_duration_seconds) do |metric|
+    metric.observe(event.duration / 1000, labels: {source: "email-load"})
+  end
+end
+
+ActiveSupport::Notifications.subscribe("file.spectrum_json_act") do |event|
+  Metrics(:api_response_duration_seconds) do |metric|
+    metric.observe(event.duration / 1000, labels: {source: "file-load"})
+  end
+end
+
+ActiveSupport::Notifications.subscribe("text.spectrum_json_act") do |event|
+  Metrics(:api_response_duration_seconds) do |metric|
+    metric.observe(event.duration / 1000, labels: {source: "text-load"})
+  end
+end
+
+#ActiveSupport::Notifications.subscribe("solr_results.spectrum_search_engine_solr") do |event|
+#end
+
+ActiveSupport::Notifications.subscribe("primo_results.spectrum_search_engine_primo") do |event|
+  # TODO: Add logging for primo search results
+  # event.payload[:results].docs do |record|
+  # begin
+  #   libkey_link = doc["bestIntegratorLink"]&.fetch("bestLink", nil)
+  #   primo_link = if doc.link_to_resource?
+  #     doc.link_to_resource
+  #   else
+  #     "https://mgetit.lib.umich.edu/resolve?#{doc.openurl}"
+  #   end
+  # rescue
+  # end
+end

--- a/lib/metrics.rb
+++ b/lib/metrics.rb
@@ -1,0 +1,126 @@
+require "yaml"
+require "erb"
+require "prometheus/middleware/collector"
+require "active_support/notifications"
+
+module Metrics
+  module NoOpMetric
+    def self.increment(*)
+    end
+
+    def self.observe(*)
+    end
+  end
+
+  class Middleware < Prometheus::Middleware::Collector
+    protected
+
+    def init_request_metrics
+      requests_name = :"#{@metrics_prefix}_requests_total"
+      durations_name = :"#{@metrics_prefix}_request_duration_seconds"
+      @requests = @registry.get(requests_name) || NoOpMetric
+      @durations = @registry.get(durations_name) || NoOpMetric
+    end
+
+    def init_exception_metrics
+      exceptions_name = :"#{@metrics_prefix}_exceptions_total"
+      @exceptions = @registry.get(exceptions_name) || NoOpMetric
+    end
+  end
+
+  class << self
+    def load_config(filename = "config/metrics.yml")
+      config = YAML.load(ERB.new(File.read(filename)).result)
+      configure_data_store(config["data_store"])
+      configure_metrics(config["metrics"])
+      configure_puma_variables(config["puma"])
+      configure_subscriptions(config["subscriptions"])
+      Yabeda.configure!
+    end
+
+    def configure_subscriptions(config)
+      return unless config
+      require File.expand_path(config, File.expand_path('..', __dir__))
+    end
+
+    def configure_puma(puma)
+      puma.activate_control_app(@control_app_url, @control_app_token)
+      puma.plugin :yabeda
+      puma.plugin :yabeda_prometheus
+      puma.prometheus_exporter_url(@prometheus_exporter_url)
+      puma.on_worker_boot do
+        uri = URI(@prometheus_exporter_url)
+        ObjectSpace.each_object(TCPServer).each do |server|
+          next if server.closed?
+          family, port, host, _ = server.addr
+          if family == "AF_INET" && port == uri.port && host == uri.host
+            server.close
+          end
+        end
+      end
+      if @data_store_dir
+        puma.on_prometheus_exporter_boot do
+          Dir[File.join(@data_store_dir, "*.bin")].each do |file_path|
+            File.unlink(file_path)
+          end
+        end
+      end
+    end
+
+    def registry
+      Prometheus::Client.registry
+    end
+
+    private
+
+    def configure_puma_variables(config)
+      @control_app_url = config["control_app_url"]
+      @control_app_token = if (token = config["control_app_token"])
+        {auth_token: token}
+      else
+        {no_token: true}
+      end
+      @prometheus_exporter_url = config["prometheus_exporter_url"]
+    end
+
+    def configure_metrics(metrics)
+      metrics.each do |metric|
+        case metric["type"]
+        when "counter", "summary", "gague"
+          registry.send(
+            metric["type"],
+            metric["name"].to_sym,
+            docstring: metric["docstring"],
+            labels: (metric["labels"] || []).map(&:to_sym),
+            preset_labels: metric["preset_labels"] || {},
+            store_settings: metric["store_settings"] || {}
+          )
+        when "histogram"
+          registry.histogram(
+            metric["name"].to_sym,
+            docstring: metric["docstring"],
+            labels: (metric["labels"] || []).map(&:to_sym),
+            preset_labels: metric["preset_labels"] || {},
+            buckets: metric["buckets"] || Prometheus::Client::Histogram::DEFAULT_BUCKETS,
+            store_settings: metric["store_settings"] || {}
+          )
+        end
+      end
+    end
+
+    def configure_data_store(config)
+      return unless config
+      if config["class"] == "Prometheus::Client::DataStores::DirectFileStore"
+        @data_store_dir = config["dir"]
+        return unless @data_store_dir
+        Prometheus::Client.config.data_store =
+          Prometheus::Client::DataStores::DirectFileStore.new(dir: @data_store_dir)
+      end
+    end
+  end
+end
+
+def Metrics(name)
+  metric = Metrics.registry.get(name)
+  yield metric if metric
+end

--- a/local-gems/spectrum-config/lib/spectrum/search_engines/solr.rb
+++ b/local-gems/spectrum-config/lib/spectrum/search_engines/solr.rb
@@ -32,7 +32,11 @@ module Spectrum
 
         @params[:qq] ||= '"' + RSolr.solr_escape(@params[:q]) + '"'
 
-        @response = Response.for(@solr.post("select", params: @params))
+        ActiveSupport::Notifications.instrument("solr_search.spectrum_search_engine_solr", source_id: @source.id, params: @params) do
+          @response = Response.for(@solr.post("select", params: @params))
+        end
+        ActiveSupport::Notifications.instrument("solr_results.spectrum_search_engine_solr", results: @response) do
+        end
       end
 
       def total_items

--- a/local-gems/spectrum-json/lib/spectrum/json/app/search.rb
+++ b/local-gems/spectrum-json/lib/spectrum/json/app/search.rb
@@ -77,10 +77,12 @@ module Spectrum
           )
 
           if source.holdings
-            full_response[:response].each do |record|
-              holdings_request = Spectrum::Request::Holdings.new({id: record[:uid]})
-              holdings_response = Spectrum::Response::Holdings.new(source, holdings_request)
-              record.merge!(holdings: holdings_response.renderable)
+            ActiveSupport::Notifications.instrument("search_results_holdings_retrieval.spectrum_json_search", full_response: full_response) do
+              full_response[:response].each do |record|
+                holdings_request = Spectrum::Request::Holdings.new({id: record[:uid]})
+                holdings_response = Spectrum::Response::Holdings.new(source, holdings_request)
+                record.merge!(holdings: holdings_response.renderable)
+              end
             end
           else
             full_response[:response].each do |record|
@@ -101,8 +103,10 @@ module Spectrum
               spectrum_request
             )
             holdings_response = if source.holdings
-              holdings_request = Spectrum::Request::Holdings.new(request)
-              Spectrum::Response::Holdings.new(source, holdings_request)
+              ActiveSupport::Notifications.instrument("single_record_holdings_retrieval.spectrum_json_search", spectrum_response: spectrum_response) do
+                holdings_request = Spectrum::Request::Holdings.new(request)
+                Spectrum::Response::Holdings.new(source, holdings_request)
+              end
             else
               Spectrum::Response::NullHoldings.new
             end

--- a/local-gems/spectrum-json/lib/spectrum/request/action.rb
+++ b/local-gems/spectrum-json/lib/spectrum/request/action.rb
@@ -23,8 +23,10 @@ module Spectrum
       def items
         return @items if @items
         ret = []
-        each_item do |item|
-          ret << item
+        ActiveSupport::Notifications.instrument("#{self.class.name.to_lower}.spectrum_json_act", data: @data, username: @username, role: @role) do
+          each_item do |item|
+            ret << item
+          end
         end
         @items = ret
       end

--- a/local-gems/spectrum-json/lib/spectrum/request/email.rb
+++ b/local-gems/spectrum-json/lib/spectrum/request/email.rb
@@ -41,8 +41,10 @@ module Spectrum
       def items
         return @items if @items
         ret = []
-        each_item do |item|
-          ret << item
+        ActiveSupport::Notifications.instrument("email.spectrum_json_act", data: @data, username: @username, role: @role) do
+          each_item do |item|
+            ret << item
+          end
         end
         @items = ret
       end

--- a/local-gems/spectrum-json/lib/spectrum/request/file.rb
+++ b/local-gems/spectrum-json/lib/spectrum/request/file.rb
@@ -32,8 +32,10 @@ module Spectrum
       def items
         return @items if @items
         ret = []
-        each_item do |item|
-          ret << item
+        ActiveSupport::Notifications.instrument("file.spectrum_json_act", data: @data, username: @username, role: @role) do
+          each_item do |item|
+            ret << item
+          end
         end
         @items = ret
       end

--- a/local-gems/spectrum-json/lib/spectrum/request/text.rb
+++ b/local-gems/spectrum-json/lib/spectrum/request/text.rb
@@ -36,8 +36,10 @@ module Spectrum
       def items
         return @items if @items
         ret = []
-        each_item do |item|
-          ret << item
+        ActiveSupport::Notifications.instrument("text.spectrum_json_act", data: @data, username: @username, role: @role) do
+          each_item do |item|
+            ret << item
+          end
         end
         @items = ret
       end


### PR DESCRIPTION
    Consolidate metrics setup and exporter config
    
    Streamline the Metrics collector and exporter
    * New middleware that adds some flexibility in metrics collection
    * ActiveSupport::Notification subscriptions for metric recording
    * Clean up the puma.rb
    * Move metric definitions into a config file
    * Put the subscriptions into a config file
