### PR TITLE
[LIBSEARCH-1055] Update Shapiro locations in Catalog Advanced Search

### DIFF
--- a/config/locColl.yaml
+++ b/config/locColl.yaml
@@ -288,6 +288,11 @@ SHAP:
     SHAP PRON: '2nd floor Browsing Collection - Shelved by author'
     SHAP GAME: 'Video Games - 4th Floor'
     SHAP GAMEB: 'Video Games - 4th Floor - Books'
+    SHAP DISP: 'On Display - Hatcher/Shapiro'
+    SHAP FLOW: 'Shapiro - Overflow Collection'
+    SHAP GOV: 'Shapiro Basement Government Publications'
+    SHAP SERU: 'Unbound serials'
+    SHAP UNASSIGNED: 'Unassigned location'
 SPEC: 
   desc: 'Special Collections' 
   collections: 

--- a/config/locColl.yaml
+++ b/config/locColl.yaml
@@ -273,7 +273,6 @@ SHAP:
   desc: 'Shapiro'
   collections:
     ALL: All collections
-    SHAP SBCS: 'Basement Compact Shelving'
     SHAP ATL: 'Atlases & Maps - 4th floor'
     SHAP DIS: 'Dissertations/Masters - 4th floor'
     SHAP SCI: 'Science Book Stacks - 4th floor'
@@ -286,7 +285,6 @@ SHAP:
     SHAP COLSC: 'College and Career Success Collection - 1st Floor'
     SHAP DLAB: 'Design Lab'
     SHAP OVR: 'Undergrad Oversize - basement'
-    SHAP PER: 'Undergrad Periodical Shelves - 2nd Floor'
     SHAP PRON: '2nd floor Browsing Collection - Shelved by author'
     SHAP GAME: 'Video Games - 4th Floor'
     SHAP GAMEB: 'Video Games - 4th Floor - Books'


### PR DESCRIPTION
# Overview
The Alma data for Shapiro locations has been updated. The location list has been updated to reflect that.

These Shapiro location codes have been added:
* On Display - Hatcher/Shapiro (DISP)
* Shapiro - Overflow Collection (FLOW)
* Shapiro Basement Government Publications (GOV)
* Unbound serials (SERU)
* Unassigned location (UNASSIGNED)

These Shapiro locations have been removed:
* Basement Compact Shelving (SBCS)
* Undergrad Periodical Shelves - 2nd Floor (PER)

This pull request closes [LIBSEARCH-1055](https://mlit.atlassian.net/browse/LIBSEARCH-1055).