### PR TITLE
[LIBSEARCH-1052] Change position of Abstract in Articles medium view results

### DIFF
--- a/config/fields.yml
+++ b/config/fields.yml
@@ -866,9 +866,6 @@
   filters:
     - id: sanitize
       method: sanitize
-  metadata_component:
-    medium:
-      type: plain
 
 - id: subject
   metadata:


### PR DESCRIPTION
# Overview
The positioning of the `abstract` field [has changed](https://github.com/mlibrary/search/pull/524) for medium Article records. The field no longer needs to be displayed in the metadata.

This pull request fixes [LIBSEARCH-1052](https://mlit.atlassian.net/browse/LIBSEARCH-1052).