### PR TITLE
LIBSEARCH-971 Punctuation out of place

### DIFF
--- a/config/fields.yml
+++ b/config/fields.yml
@@ -2252,6 +2252,8 @@
         sub: '[abcdefgjklnpqtu4]'
         label: display
         join: ' '
+        prefix: "\u2068"
+        suffix: "\u2069"
         filters:
           - sub: "[4]"
             value_match: "https?://"
@@ -2266,6 +2268,8 @@
         sub: '[abcdefgjklnpqtu4]'
         label: display
         join: ' '
+        prefix: "\u2068"
+        suffix: "\u2069"
         where:
           - sub: '6'
             start_with: ['100', '110', '111']
@@ -2313,6 +2317,8 @@
         label: display
         join: ' '
         ind2: '[^2]'
+        prefix: "\u2068"
+        suffix: "\u2069"
         where:
           - sub: t
             exists: false
@@ -2333,6 +2339,8 @@
         sub: '[abcdefgjklnpqu4]'
         label: display
         join: ' '
+        prefix: "\u2068"
+        suffix: "\u2069"
         where:
           - sub: '6'
             start_with: ['700', '710', '711']
@@ -2359,11 +2367,6 @@
       quoted_search: true
       browse_variant: author
       browse_text: Browse in author list
-#      type: search2
-#      variant: filtered
-#      scope: author
-#      text_field: display
-#      value_field: search
 
 - id: ris_contributors
   z3988:


### PR DESCRIPTION
On RTL author and contributor fields, punctuation is out of place. This change:
* Refactors the filtered_labeling_aggregator to carry a possible prefix and suffix
* Adds the directionality prefix and suffix to the start and end of the fields for main_author and contributor..