### PR TITLE
LIBSEARCH-439 Primo peer reviwed field

### DIFF
--- a/config/fields.yml
+++ b/config/fields.yml
@@ -4320,6 +4320,18 @@
     short_desc: All fields
   viewable: false
 
+- id: peer_reviewed
+  metadata:
+    name: Peer reviewed
+    short_desc: Peer reviewed
+  field: lds50
+  filters:
+  - id: scalar
+    method: scalar
+  mapping:
+    peer_reviewed: "Y"
+    null: "N"
+
 - id: primo_is_scholarly
   uid: is_scholarly
   metadata:

--- a/config/foci/05-primo-articles.yml
+++ b/config/foci/05-primo-articles.yml
@@ -93,6 +93,7 @@ fields:
 - primo_times_cited
 - abstract
 - articles_edition
+- peer_reviewed
 
 # Searching
 - primo_all_fields

--- a/local-gems/spectrum-config/lib/spectrum/config/filter.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/filter.rb
@@ -13,6 +13,10 @@ module Spectrum
         @decoder = HTMLEntities.new
       end
 
+      def scalar(value, _)
+        [value].flatten.compact.first
+      end
+
       def boolean(value, request)
         case value
         when Array


### PR DESCRIPTION
The peer_reviwed field is either Y when the Primo API results indicate a record is peer reviwed.  Or N otherwise.