### PR TITLE
LIBSEARCH-148 Author lists in Articles

### DIFF
--- a/config/fields.yml
+++ b/config/fields.yml
@@ -4149,7 +4149,8 @@
     id: rft.au
   ris:
     - AU
-  field: creator
+  field: au
+  query_field: creator
   metadata:
     name: Author
     short_desc: Creator

--- a/local-gems/spectrum-config/lib/spectrum/config/field.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/field.rb
@@ -113,9 +113,9 @@ module Spectrum
         @metadata   = Metadata.new(args['metadata'])
         @field      = args['field'] || args['id']
         @query_field = args['query_field'] || @field
-        @query_precision = args['query_precision'] || @field
+        @query_precision = args['query_precision'] || "contains"
         @query_feedback = args['query_feedback'] || @field
-        @facet_field = args['facet_field'] || @field
+        @facet_field = args['facet_field'] || @query_field
         @facet_query_field = args['facet_query_field'] || @facet_field
         @uid = args['uid'] || args['id']
         @query_params = args['query_params'] || {}


### PR DESCRIPTION
This fetches author lists from a field where they are an array. It also ensures that search queries continue to work, and fixes default values related to query generation in primo.