### PR TITLE
Reducing cardinality in api response metrics

### DIFF
--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -29,17 +29,15 @@ metrics:
   docstring: "The API response duration for requests made by Spectrum."
   labels:
   - source
-  - query_requested_records
   - query_word_count
   - query_has_booleans
   - query_has_quoted_phrases
-  - response_records_matched
   - response_total_items_magnitude
-  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 20, 30]
+  buckets: [0.05, 0.1, 0.5, 1, 2.5, 5, 10, 15, 30, 60]
 - type: histogram
   name: cookie_size_bytes
   docstring: "The http request cookie sizes in bytes"
-  buckets: [500, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 7500, 8000]
+  buckets: [500, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 7500, 8000, 8200]
 - type: counter
   name: cookie_purges_total
   docstring: "The total number of cookie purges initiated by spectrum"

--- a/config/subscriptions.rb
+++ b/config/subscriptions.rb
@@ -50,11 +50,9 @@ ActiveSupport::Notifications.subscribe("primo_search.spectrum_search_engine_prim
   Metrics(:api_response_duration_seconds) do |metric|
     metric.observe(event.payload[:duration], labels: {
       source: event.payload[:source_id],
-      query_requested_records: Metrics.results_count_bucketing(event.payload[:params].requested_records),
       query_word_count: event.payload[:params].keyword_count,
       query_has_booleans: event.payload[:params].has_booleans?,
       query_has_quoted_phrases: event.payload[:params].has_quotes?,
-      response_records_matched: Metrics.results_count_bucketing(event.payload[:response].length),
       response_total_items_magnitude: event.payload[:response].total_items_magnitude
     })
   end
@@ -78,11 +76,9 @@ ActiveSupport::Notifications.subscribe("libkey_search.spectrum_search_engine_pri
   Metrics(:api_response_duration_seconds) do |metric|
     metric.observe(event.payload[:duration], labels: {
       source: event.payload[:source_id],
-      query_requested_records: Metrics.results_count_bucketing(event.payload[:params].requested_records),
       query_word_count: event.payload[:params].keyword_count,
       query_has_booleans: event.payload[:params].has_booleans?,
       query_has_quoted_phrases: event.payload[:params].has_quotes?,
-      response_records_matched: Metrics.results_count_bucketing(event.payload[:response].length),
       response_total_items_magnitude: event.payload[:response].total_items_magnitude
     })
   end
@@ -92,11 +88,9 @@ ActiveSupport::Notifications.subscribe("solr_search.spectrum_search_engine_solr"
   Metrics(:api_response_duration_seconds) do |metric|
     metric.observe(event.payload[:duration], labels: {
       source: event.payload[:source_id],
-      query_requested_records: Metrics.results_count_bucketing(event.payload[:params].requested_records),
       query_word_count: event.payload[:params].keyword_count,
       query_has_booleans: event.payload[:params].has_booleans?,
       query_has_quoted_phrases: event.payload[:params].has_quotes?,
-      response_records_matched: Metrics.results_count_bucketing(event.payload[:response].length),
       response_total_items_magnitude: event.payload[:response].total_items_magnitude
     })
   end
@@ -107,16 +101,13 @@ ActiveSupport::Notifications.subscribe("search_results_holdings_retrieval.spectr
   query_word_count = "n/a"
   query_has_booleans = "n/a"
   query_has_quotes = "n/a"
-  response_records_matched = "n/a"
   response_total_items_magnitude = "n/a"
   Metrics(:api_response_duration_seconds) do |metric|
     metric.observe(event.duration / 1000, labels: {
       source: "alma-search-holdings",
-      query_requested_records: query_request_records,
       query_word_count: query_word_count,
       query_has_booleans: query_has_booleans,
       query_has_quoted_phrases: query_has_quotes,
-      response_records_matched: response_records_matched,
       response_total_items_magnitude: response_total_items_magnitude
     })
   end
@@ -127,118 +118,100 @@ ActiveSupport::Notifications.subscribe("single_record_holdings_retrieval.spectru
   query_word_count = "n/a"
   query_has_booleans = "n/a"
   query_has_quotes = "n/a"
-  response_records_matched = "n/a"
   response_total_items_magnitude = "n/a"
   Metrics(:api_response_duration_seconds) do |metric|
     metric.observe(event.duration / 1000, labels: {
       source: "alma-single-holdings",
-      query_requested_records: query_request_records,
       query_word_count: query_word_count,
       query_has_booleans: query_has_booleans,
       query_has_quoted_phrases: query_has_quotes,
-      response_records_matched: response_records_matched,
       response_total_items_magnitude: response_total_items_magnitude
     })
   end
 end
 
 ActiveSupport::Notifications.subscribe("email.spectrum_json_act") do |event|
-  query_request_records = "n/a"
-  query_word_count = "n/a"
-  query_has_booleans = "n/a"
-  query_has_quotes = "n/a"
-  response_records_matched = "n/a"
-  response_total_items_magnitude = "n/a"
-  Metrics(:api_response_duration_seconds) do |metric|
-    metric.observe(event.duration / 1000, labels: {
-      source: "email-load",
-      query_requested_records: query_request_records,
-      query_word_count: query_word_count,
-      query_has_booleans: query_has_booleans,
-      query_has_quoted_phrases: query_has_quotes,
-      response_records_matched: response_records_matched,
-      response_total_items_magnitude: response_total_items_magnitude
-    })
-  end
+#  query_request_records = "n/a"
+#  query_word_count = "n/a"
+#  query_has_booleans = "n/a"
+#  query_has_quotes = "n/a"
+#  response_total_items_magnitude = "n/a"
+#  Metrics(:api_response_duration_seconds) do |metric|
+#    metric.observe(event.duration / 1000, labels: {
+#      source: "email-load",
+#      query_word_count: query_word_count,
+#      query_has_booleans: query_has_booleans,
+#      query_has_quoted_phrases: query_has_quotes,
+#      response_total_items_magnitude: response_total_items_magnitude
+#    })
+#  end
 end
 
 ActiveSupport::Notifications.subscribe("file.spectrum_json_act") do |event|
-  query_request_records = "n/a"
-  query_word_count = "n/a"
-  query_has_booleans = "n/a"
-  query_has_quotes = "n/a"
-  response_records_matched = "n/a"
-  response_total_items_magnitude = "n/a"
-  Metrics(:api_response_duration_seconds) do |metric|
-    metric.observe(event.duration / 1000, labels: {
-      source: "file-load",
-      query_requested_records: query_request_records,
-      query_word_count: query_word_count,
-      query_has_booleans: query_has_booleans,
-      query_has_quoted_phrases: query_has_quotes,
-      response_records_matched: response_records_matched,
-      response_total_items_magnitude: response_total_items_magnitude
-    })
-  end
+#  query_request_records = "n/a"
+#  query_word_count = "n/a"
+#  query_has_booleans = "n/a"
+#  query_has_quotes = "n/a"
+#  response_total_items_magnitude = "n/a"
+#  Metrics(:api_response_duration_seconds) do |metric|
+#    metric.observe(event.duration / 1000, labels: {
+#      source: "file-load",
+#      query_word_count: query_word_count,
+#      query_has_booleans: query_has_booleans,
+#      query_has_quoted_phrases: query_has_quotes,
+#      response_total_items_magnitude: response_total_items_magnitude
+#    })
+#  end
 end
 
 ActiveSupport::Notifications.subscribe("text.spectrum_json_act") do |event|
-  query_request_records = "n/a"
-  query_word_count = "n/a"
-  query_has_booleans = "n/a"
-  query_has_quotes = "n/a"
-  response_records_matched = "n/a"
-  response_total_items_magnitude = "n/a"
-  Metrics(:api_response_duration_seconds) do |metric|
-    metric.observe(event.duration / 1000, labels: {
-      source: "text-load",
-      query_requested_records: query_request_records,
-      query_word_count: query_word_count,
-      query_has_booleans: query_has_booleans,
-      query_has_quoted_phrases: query_has_quotes,
-      response_records_matched: response_records_matched,
-      response_total_items_magnitude: response_total_items_magnitude
-    })
-  end
+#  query_request_records = "n/a"
+#  query_word_count = "n/a"
+#  query_has_booleans = "n/a"
+#  query_has_quotes = "n/a"
+#  response_total_items_magnitude = "n/a"
+#  Metrics(:api_response_duration_seconds) do |metric|
+#    metric.observe(event.duration / 1000, labels: {
+#      source: "text-load",
+#      query_word_count: query_word_count,
+#      query_has_booleans: query_has_booleans,
+#      query_has_quoted_phrases: query_has_quotes,
+#      response_total_items_magnitude: response_total_items_magnitude
+#    })
+#  end
 end
 
 ActiveSupport::Notifications.subscribe("fetch_records.spectrum_specialists") do |event|
-  Metrics(:api_response_duration_seconds) do |metric|
-    metric.observe(event.payload[:duration], labels: {
-      source: "catalog-solr-specialists",
-      query_requested_records: "n/a",
-      query_word_count: "n/a",
-      query_has_booleans: "n/a",
-      query_has_quoted_phrases: "n/a",
-      response_records_matched: "n/a",
-      response_total_items_magnitude: "n/a"
-    })
-  end
+#  Metrics(:api_response_duration_seconds) do |metric|
+#    metric.observe(event.payload[:duration], labels: {
+#      source: "catalog-solr-specialists",
+#      query_word_count: "n/a",
+#      query_has_booleans: "n/a",
+#      query_has_quoted_phrases: "n/a",
+#      response_total_items_magnitude: "n/a"
+#    })
+#  end
 end
 
 ActiveSupport::Notifications.subscribe("fetch_specialists_2step.spectrum_specialists") do |event|
-  Metrics(:api_response_duration_seconds) do |metric|
-    metric.observe(event.payload[:duration], labels: {
-      source: "website-solr-specialists-2nd-step",
-      query_requested_records: "n/a",
-      query_word_count: "n/a",
-      query_has_booleans: "n/a",
-      query_has_quoted_phrases: "n/a",
-      response_records_matched: "n/a",
-      response_total_items_magnitude: "n/a"
-    })
-  end
+#  Metrics(:api_response_duration_seconds) do |metric|
+#    metric.observe(event.payload[:duration], labels: {
+#      source: "website-solr-specialists-2nd-step",
+#      query_word_count: "n/a",
+#      query_has_booleans: "n/a",
+#      query_has_quoted_phrases: "n/a",
+#      response_total_items_magnitude: "n/a"
+#    })
+#  end
 end
 
 ActiveSupport::Notifications.subscribe("fetch_specialists_1step.spectrum_specialists") do |event|
   Metrics(:api_response_duration_seconds) do |metric|
     metric.observe(event.payload[:duration], labels: {
       source: "website-solr-specialists-1step",
-      query_requested_records: "n/a",
       query_word_count: "n/a",
       query_has_booleans: "n/a",
       query_has_quoted_phrases: "n/a",
-      response_records_matched: "n/a",
       response_total_items_magnitude: "n/a"
     })
   end


### PR DESCRIPTION
* Dropping labels for query_requested_records and response_records_matched
* Reduced values in the histogram
* Reduced some of the values in the source