### PR TITLE
Add rft_id=info:primo/$id to the OpenURL

### DIFF
--- a/local-gems/spectrum-config/lib/spectrum/search_engines/primo/doc.rb
+++ b/local-gems/spectrum-config/lib/spectrum/search_engines/primo/doc.rb
@@ -98,7 +98,7 @@ module Spectrum
         end
 
         def openurl
-          @delivery['almaOpenurl'].sub(/^.*\?/,'')
+          @delivery['almaOpenurl'].sub(/^.*\?/,'')  + "&rft_id=info%3Aprimo%2F#{self["id"]}"
         end
 
         def empty?


### PR DESCRIPTION
We might be able to leverage Primo's native UI's link resolver in M Get It.

To do so we need to fetch data from the primo API.  So we will have to pass the record id along.