### PR TITLE
update alma_rest_client; turn off persistence

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "spectrum-json", path: "local-gems/spectrum-json"
 
 gem "alma_rest_client",
   git: "https://github.com/mlibrary/alma_rest_client",
-  tag: "alma_rest_client/v2.1.0"
+  tag: "alma_rest_client/v2.2.0"
 
 gem "mlibrary_search_parser",
   git: "https://github.com/mlibrary/mlibrary_search_parser",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/mlibrary/alma_rest_client
-  revision: 47b9e9b67b70dc66abb0f81dfb1ad6aa44f50224
-  tag: alma_rest_client/v2.1.0
+  revision: f94276a6e83d1526f7ec91c66aad1cee8b80f97d
+  tag: alma_rest_client/v2.2.0
   specs:
-    alma_rest_client (2.1.0)
+    alma_rest_client (2.2.0)
       activesupport (~> 8.0)
       faraday
       faraday-retry

--- a/local-gems/spectrum-json/lib/spectrum/alma_client.rb
+++ b/local-gems/spectrum-json/lib/spectrum/alma_client.rb
@@ -1,5 +1,8 @@
 require "alma_rest_client"
 class Spectrum::AlmaClient
+  AlmaRestClient.configure do |config|
+    config.http_adapter = [:httpx, {persistent: false}]
+  end
   def self.client
     AlmaRestClient.client
   end


### PR DESCRIPTION
In production we were getting errors like: `Errno::EMFILE - too many open files`. This is mentioned as a potential problem in the [HTTPX Faraday adapter docs](https://honeyryderchuck.gitlab.io/httpx/wiki/Faraday-Adapter)

The AlmaRestClient gem has been updated to allow sending an array of parameters for the `http_adapter`. This PR uses the updated gem version, and sets `persistent: false` for the httpx adapter.