### PR TITLE
add follow redirects to Alma Rest Client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem "alma_rest_client",
   git: "https://github.com/mlibrary/alma_rest_client",
   tag: "alma_rest_client/v2.2.0"
 
+gem "faraday-follow_redirects"
+
 gem "mlibrary_search_parser",
   git: "https://github.com/mlibrary/mlibrary_search_parser",
   branch: "main"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -396,6 +396,7 @@ DEPENDENCIES
   alma_rest_client!
   dotenv
   down
+  faraday-follow_redirects
   fiddle
   httpclient
   ipresolver!

--- a/local-gems/spectrum-json/lib/spectrum/alma_client.rb
+++ b/local-gems/spectrum-json/lib/spectrum/alma_client.rb
@@ -1,9 +1,13 @@
 require "alma_rest_client"
+require "faraday/follow_redirects"
 class Spectrum::AlmaClient
   AlmaRestClient.configure do |config|
     config.http_adapter = [:httpx, {persistent: false}]
   end
   def self.client
-    AlmaRestClient.client
+    conn = Faraday.new do |faraday|
+      faraday.response :follow_redirects
+    end
+    AlmaRestClient::Client.new(conn)
   end
 end

--- a/local-gems/spectrum-json/lib/spectrum/decorators/physical_item_decorator.rb
+++ b/local-gems/spectrum-json/lib/spectrum/decorators/physical_item_decorator.rb
@@ -61,6 +61,7 @@ module Spectrum::Decorators
     ETAS_START = "Full text available,"
 
     extend Forwardable
+
     def_delegators :@work_order_option, :in_labeling?
 
     attr_reader :hathi_holding


### PR DESCRIPTION
For `AlmaRestClient` requests that result in a redirect (ex `items?item_barcode=some_barcode`) the client does not follow redirects. (It probably did when we were using `httparty`, but we're using `Faraday` now.) This PR adds in the `follow_redirects` middleware and adds it to the AlmaRestClient object.