### PR TITLE
LIBSEARCH-1129 SPEC PAPYR

### DIFF
--- a/config/locColl.yaml
+++ b/config/locColl.yaml
@@ -264,6 +264,7 @@ SPEC:
     SPEC CUL: 'Janice Bluestein Longone Culinary Archive'
     SPEC JHC: 'Jewish Heritage Collection' 
     SPEC LABD: 'Joseph A. Labadie Collection' 
+    SPEC SCH-PAPYR: 'Papyrology Reference Collection'
     SPEC SCB-PARS: 'Parsons-Rau Collection' 
     SPEC WOR: 'Philippine History Collection' 
     SPEC SCB-GOSL: 'Pop-Up and Movable Books' 


### PR DESCRIPTION
Adds Papyrology to Special Collections advanced search

This resolves [LIBSEARCH-1129](https://mlit.atlassian.net/browse/LIBSEARCH-1129)