### PR TITLE
Prioritize alma digital

### DIFF
--- a/local-gems/spectrum-json/lib/spectrum/bib_record.rb
+++ b/local-gems/spectrum-json/lib/spectrum/bib_record.rb
@@ -179,7 +179,7 @@ module Spectrum
 
     # non-HathiTrust Electronic Holdings or Digital Holdings
     def elec_holdings
-      holdings.select { |x| ["ELEC", "ALMA_DIGITAL"].any? { |y| x.library == y } }
+      holdings.select { |x| ["ELEC", "ALMA_DIGITAL"].any? { |y| x.library == y } }.sort_by(&:order)
     end
 
     def physical_holdings?
@@ -211,6 +211,12 @@ module Spectrum
         ""
       end
 
+      # for ordering in holding results when there's a mix of holdings. Default
+      # is at the bottom of the list
+      def order
+        999999
+      end
+
       def finding_aid
         false
       end
@@ -230,6 +236,11 @@ module Spectrum
     class DigitalHolding < Holding
       def self.match?(holding)
         holding["library"] == "ALMA_DIGITAL"
+      end
+
+      # These should be prioritized over Electronic Holdings
+      def order
+        1
       end
       ["public_note", "link", "link_text", "delivery_description", "label"].each do |name|
         define_method(name) do

--- a/spec/spectrum/bib_record_spec.rb
+++ b/spec/spectrum/bib_record_spec.rb
@@ -185,6 +185,18 @@ describe Spectrum::BibRecord do
           @hol[0]["library"] = "ALMA_DIGITAL"
           expect(subject.elec_holdings.count).to eq(1)
         end
+        it "returns alma digital holdings first" do
+          @hol.push({
+            "library" => "ALMA_DIGITAL",
+            "link" => "https://somelink.doesnotwork",
+            "link_text" => "Available online",
+            "delivery_description" => "some delivery description",
+            "label" => "some label",
+            "public_note" => "some note"
+
+          })
+          expect(subject.elec_holdings.first.library).to eq("ALMA_DIGITAL")
+        end
       end
       context "finding_aid" do
         it "returns nil when finding_aid is false" do


### PR DESCRIPTION
We've decided that we'd like to prioritize Alma Digital items over other electronic items. This PR adds an order method holdings, and Alma Digital items are given a higher priority. 