### PR TITLE
Bugfix for MarcMatcherWhereExists

### DIFF
--- a/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_clause.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_clause.rb
@@ -21,7 +21,7 @@ module Spectrum
 
         def get_type(config)
           return nil unless config&.respond_to?(:[])
-          registry.find {|item| config[item.type] }
+          registry.find {|item| config.has_key?(item.type) }
         end
 
         def registry

--- a/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_exists.rb
+++ b/local-gems/spectrum-config/lib/spectrum/config/marc_matcher_where_exists.rb
@@ -7,12 +7,16 @@ module Spectrum
       def initialize(cfg)
         cfg ||= {}
         self.sub = cfg['sub']
-        self.values = Struct.new(:ret) { def include?(val) ret end }.new(true)
+        self.values = cfg['exists']
       end
 
       def match?(field)
         return true unless sub
-        !find_all(field).empty?
+        if find_all(field).empty?
+          return !values
+        else
+          return values
+        end
       end
     end
   end


### PR DESCRIPTION
Problem 1: MarcMatcherWhereExists for exists: false was not being created.
Problem 2: The value for exists: false was not being used.

Fix 1: Check on existance of key, not truthiness of key.
Fix 2: Check on whether the subfield exists.  Return the value for exists if yes.  Otherwise the negated value for exists.